### PR TITLE
Automatically find stdlib

### DIFF
--- a/front/shackle-ls/src/main.rs
+++ b/front/shackle-ls/src/main.rs
@@ -4,9 +4,8 @@ use lsp_types::{
 	CompletionOptions, HoverProviderCapability, InitializeParams, OneOf, ServerCapabilities,
 	TextDocumentIdentifier, TextDocumentSyncKind,
 };
-use std::path::PathBuf;
+use std::ops::Deref;
 use std::sync::Arc;
-use std::{env, ops::Deref};
 use std::{error::Error, path::Path};
 
 use lsp_server::{Connection, ErrorCode, ExtractError, Message, ResponseError};
@@ -38,14 +37,7 @@ pub struct LanguageServerDatabase {
 impl LanguageServerDatabase {
 	pub fn new(connection: &Connection) -> Self {
 		let fs = vfs::Vfs::new();
-		let mut db = CompilerDatabase::with_file_handler(Box::new(fs.clone()));
-		let mut search_dirs = Vec::new();
-		let stdlib_dir = env::var("MZN_STDLIB_DIR");
-		match stdlib_dir {
-			Ok(v) => search_dirs.push(PathBuf::from(v)),
-			_ => {}
-		}
-		db.set_search_directories(Arc::new(search_dirs));
+		let db = CompilerDatabase::with_file_handler(Box::new(fs.clone()));
 		Self {
 			vfs: fs,
 			pool: threadpool::Builder::new().build(),

--- a/front/shackle/src/lib.rs
+++ b/front/shackle/src/lib.rs
@@ -18,12 +18,7 @@ use db::Inputs;
 use error::{MultipleErrors, ShackleError};
 use file::InputFile;
 
-use std::{
-	env,
-	path::{Path, PathBuf},
-	sync::Arc,
-	time::Instant,
-};
+use std::{path::Path, sync::Arc, time::Instant};
 
 use crate::{
 	hir::db::Hir,
@@ -45,14 +40,6 @@ pub fn parse_files(paths: Vec<&Path>) -> Result<()> {
 			.map(|p| InputFile::Path(p.to_owned()))
 			.collect(),
 	));
-
-	let mut search_dirs = Vec::new();
-	let stdlib_dir = env::var("MZN_STDLIB_DIR");
-	match stdlib_dir {
-		Ok(v) => search_dirs.push(PathBuf::from(v)),
-		_ => {}
-	}
-	db.set_search_directories(Arc::new(search_dirs));
 	let mut errors = (*db.all_diagnostics()).clone();
 	eprintln!("Done in {}ms", now.elapsed().as_millis());
 	if errors.is_empty() {


### PR DESCRIPTION
Removes the need for setting `MZN_STDLIB_DIR` since the stdlib is now in the repo.

Also makes behaviour more consistent with the old compiler which apparently uses `MZN_STDLIB_DIR` to set the share directory, not the `std` directory.