### PR TITLE
Add initial API, CLI, and legacy interpreter integration

### DIFF
--- a/crates/shackle-cli/Cargo.toml
+++ b/crates/shackle-cli/Cargo.toml
@@ -16,3 +16,4 @@ env_logger = "0.9.0"
 log = "0.4.14"
 miette = { version = "5.4.1", features = ["fancy"] }
 shackle = { path = "../shackle" }
+humantime = "2.1.0"

--- a/crates/shackle-cli/src/compile.rs
+++ b/crates/shackle-cli/src/compile.rs
@@ -17,7 +17,8 @@ impl Compile {
 	pub fn dispatch(&self) -> Result<()> {
 		for i in &self.input {
 			match i.extension().and_then(OsStr::to_str) {
-				Some("mzn") => {}
+				Some("mzn") => {},
+				Some("eprime") => {},
 				_ => {
 					return Err(Report::msg(format!(
 						"File {:?} has an unsupported file type",

--- a/crates/shackle-cli/src/main.rs
+++ b/crates/shackle-cli/src/main.rs
@@ -79,7 +79,7 @@ struct Opts {
 #[derive(Subcommand, Debug)]
 enum SubCommand {
 	Compile(Compile),
-	Solve(Solve),
+	Solve(Box<Solve>),
 	Check(Check),
 }
 

--- a/crates/shackle-cli/src/main.rs
+++ b/crates/shackle-cli/src/main.rs
@@ -7,35 +7,40 @@
 use clap::{crate_version, Args, Parser, Subcommand};
 use env_logger::{fmt::TimestampPrecision, Builder};
 use humantime::Duration;
-use miette::{Report, Result};
-use shackle::error::InternalError;
+use log::warn;
+use miette::{IntoDiagnostic, Report, Result};
+use shackle::error::{InternalError, ShackleError};
 use shackle::{Message, Model, Solver, Status};
 
 use std::ffi::OsStr;
+use std::fs::File;
 use std::panic;
 use std::path::PathBuf;
 
 /// The main function is the entry point for the `shackle` executable.
 ///
-/// It parses the command-line arguments using a Clap parser, processes the arguments, and then
-/// dispatches to called operation.
+/// It parses the command-line arguments using a Clap parser, processes the
+/// arguments, and then dispatches to called operation.
 fn main() -> Result<()> {
 	// Parse command line arguments
-	let opts: Opts = Opts::parse();
+	// TODO: Should this use Miette?
+	// let cli = Cli::try_parse().into_diagnostic()?;
+	let cli = Cli::parse();
 
-	// Initialise logger based on how many times the user used the "verbose" flag
+	// Initialise logger based on how many times the user used the "verbose"
+	// flag
 	let mut logger = Builder::new();
 	logger
 		.format_target(false)
-		.format_module_path(opts.verbose >= 2)
+		.format_module_path(cli.verbose >= 2)
 		.filter_level(log::LevelFilter::Warn)
-		.format_timestamp(match opts.verbose {
+		.format_timestamp(match cli.verbose {
 			0 => None,
 			1 => Some(TimestampPrecision::Seconds),
 			_ => Some(TimestampPrecision::Millis),
 		})
 		.parse_default_env();
-	match opts.verbose {
+	match cli.verbose {
 		0 => (),
 		1 => {
 			logger.filter_level(log::LevelFilter::Info);
@@ -52,69 +57,61 @@ fn main() -> Result<()> {
 	log::warn!("Shackle is an unfinished product not ready to be used for any purpose apart from its own development.");
 
 	// Dispatch to the correct subcommand
-	match panic::catch_unwind(|| match opts.subcmd {
+	match panic::catch_unwind(|| match cli.subcmd {
 		SubCommand::Compile(c) => c.dispatch(),
 		SubCommand::Solve(s) => s.dispatch(),
-		_ => unimplemented!(),
+		SubCommand::Check(c) => c.dispatch(),
 	}) {
 		Err(_) => Err(InternalError::new("Panic occurred during execution").into()),
 		Ok(res) => res,
 	}
 }
 
-/// A command line interface to the shackle constraint modelling and rewriting library.
-#[derive(Parser, Debug)]
-#[clap(
+/// A command line interface to the shackle constraint modelling and rewriting
+/// library.
+#[derive(Parser)]
+#[command(
     name = "shackle",
 	version = crate_version!(),
 )]
-struct Opts {
+struct Cli {
 	/// A level of verbosity, and can be used multiple times
-	#[clap(short, long, action = clap::ArgAction::Count)]
+	#[arg(short, long, action = clap::ArgAction::Count)]
 	verbose: u8,
-	#[clap(subcommand)]
+	#[command(subcommand)]
 	subcmd: SubCommand,
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand)]
 enum SubCommand {
-	Compile(Compile),
+	/// Compile a model to the intermediate form accepted by the interpreter and
+	/// output the model to a file
+	Compile(Box<Compile>),
+	///
 	Solve(Box<Solve>),
-	Check(Check),
+	Check(Box<Check>),
 }
 
 /// Solve the given model instance using the given solver
-#[derive(Args, Debug)]
+#[derive(Args)]
 struct Solve {
-	#[clap(long, default_value = "gecode")]
-	solver: String,
-	input: PathBuf,
-	#[clap(long)]
+	#[arg(long)]
 	statistics: bool,
-	#[clap(long)]
+	#[arg(long)]
 	time_limit: Option<Duration>,
+	#[command(flatten)]
+	base: Compile,
 }
 
 impl Solve {
-	/// The dispatch method checks the validity of the user input and then call the corresponding
-	/// functions in the modelling libraries.
+	/// The dispatch method checks the validity of the user input and then call
+	/// the corresponding functions in the modelling libraries.
 	pub fn dispatch(&self) -> Result<()> {
-		match self.input.extension().and_then(OsStr::to_str) {
-			Some("mzn") => {}
-			Some("eprime") => {}
-			_ => {
-				return Err(Report::msg(format!(
-					"File {:?} has an unsupported file type",
-					self.input
-				)));
-			}
-		}
-
-		// Lookup Solver definition
-		let slv = Solver::lookup(self.solver.as_str()).unwrap();
+		let (model, _data) = self.base.sort_files()?;
+		let slv = self.base.solver()?;
 
 		// Construct model, typecheck, and compile into program
-		let model = Model::from_file(self.input.clone());
+		let model = Model::from_file(model);
 		let mut program = model.compile(&slv)?;
 
 		// Set program options
@@ -143,22 +140,104 @@ impl Solve {
 }
 
 /// Check model files for correctness
-#[derive(Args, Debug)]
+#[derive(Args)]
 struct Check {
-	input: PathBuf,
+	/// Check whether all the data required to create a complete problem
+	/// instance is provided
+	#[arg(long)]
+	check_complete: bool,
+	#[command(flatten)]
+	base: Compile,
+}
+
+impl Check {
+	/// The dispatch method checks the validity of the user input and then call
+	/// the corresponding functions in the modelling libraries.
+	pub fn dispatch(&self) -> Result<()> {
+		let (model, data) = self.base.sort_files()?;
+
+		let slv = self.base.solver()?;
+		let model = Model::from_file(model);
+		let errors = model.check(&slv, &data, self.check_complete);
+
+		if errors.is_empty() {
+			Ok(())
+		} else {
+			Err(ShackleError::try_from(errors).unwrap().into())
+		}
+	}
 }
 
 /// Compile the given model to a shackle intermediate format
-#[derive(Args, Debug)]
+#[derive(Args)]
 pub struct Compile {
-	#[clap(required = true)]
-	input: PathBuf,
+	#[arg(long, default_value = "gecode")]
+	solver: String,
+	#[arg(required = true)]
+	files: Vec<PathBuf>,
 }
 
 impl Compile {
-	/// The dispatch method checks the validity of the user input and then call the corresponding
-	/// functions in the modelling libraries.
+	/// Sort through the files in the command line arguments and split the model
+	/// from the data
+	pub fn sort_files(&self) -> Result<(PathBuf, Vec<PathBuf>)> {
+		let mut model_file: Option<PathBuf> = None;
+		let mut data = Vec::with_capacity(self.files.len() - 1);
+		for f in self.files.iter() {
+			match f.extension().and_then(OsStr::to_str) {
+				Some("mzn") | Some("eprime") => {
+					if let Some(other) = model_file {
+						return Err(Report::msg(format!(
+							"detected multiple model files: `{}' and `{}'",
+							other.display(),
+							f.display()
+						)));
+					} else {
+						model_file = Some(f.clone())
+					}
+				}
+				Some("json") => data.push(f.clone()),
+				_ => {
+					return Err(Report::msg(format!(
+						"file `{:?}' has an unsupported file type",
+						model_file
+					)));
+				}
+			}
+		}
+		if let Some(f) = model_file {
+			Ok((f, data))
+		} else {
+			Err(Report::msg("no model file detected"))
+		}
+	}
+
+	/// Resolve shackle [`Solver`] from the solver command line flag
+	pub fn solver(&self) -> Result<Solver> {
+		match shackle::Solver::lookup(self.solver.as_str()) {
+			Some(slv) => Ok(slv),
+			None => Err(Report::msg(format!(
+				"no solver has been registered with the tag `{}'",
+				self.solver,
+			))),
+		}
+	}
+
+	/// The dispatch method checks the validity of the user input and then call
+	/// the corresponding functions in the modelling libraries.
 	pub fn dispatch(&self) -> Result<()> {
-		Ok(())
+		let (model, data) = self.sort_files()?;
+		if !data.is_empty() {
+			warn!("compilation only considers a model, the data files provided are ignored.")
+		}
+
+		let filename = model.with_extension("shacke.mzn");
+
+		let slv = self.solver()?;
+		let model = Model::from_file(model);
+		let prg = model.compile(&slv)?;
+
+		let mut file = File::create(filename).into_diagnostic()?;
+		prg.write(&mut file).into_diagnostic()
 	}
 }

--- a/crates/shackle/Cargo.toml
+++ b/crates/shackle/Cargo.toml
@@ -11,7 +11,6 @@ log = "0.4.14"
 miette = { version = "5.4.1" }
 rustc-hash = "1.1.0"
 salsa = { git = "https://github.com/salsa-rs/salsa" }
-serde = "1.0"
 serde_json = "1.0"
 tempfile = "3.3.0"
 thiserror = "1.0.31"

--- a/crates/shackle/Cargo.toml
+++ b/crates/shackle/Cargo.toml
@@ -9,7 +9,10 @@ edition = "2021"
 [dependencies]
 miette = { version = "5.4.1" }
 rustc-hash = "1.1.0"
+salsa = { git = "https://github.com/salsa-rs/salsa" }
+serde = "1.0"
+serde_json = "1.0"
+tempfile = "3.3.0"
 thiserror = "1.0.31"
 tree-sitter = "0.20.6"
 tree-sitter-minizinc = { path = "../../parsers/tree-sitter-minizinc" }
-salsa = { git = "https://github.com/salsa-rs/salsa" }

--- a/crates/shackle/Cargo.toml
+++ b/crates/shackle/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 edition = "2021"
 
 [dependencies]
+log = "0.4.14"
 miette = { version = "5.4.1" }
 rustc-hash = "1.1.0"
 salsa = { git = "https://github.com/salsa-rs/salsa" }

--- a/crates/shackle/src/db.rs
+++ b/crates/shackle/src/db.rs
@@ -206,10 +206,10 @@ impl salsa::Database for CompilerDatabase {
 	// fn salsa_event(&self, event_fn: salsa::Event) {
 	// 	match event_fn.kind {
 	// 		salsa::EventKind::WillExecute { database_key } => {
-	// 			eprintln!("  Executing {:?}", database_key.debug(self));
+	// 			log::trace!("  Executing {:?}", database_key.debug(self));
 	// 		}
 	// 		salsa::EventKind::DidValidateMemoizedValue { database_key } => {
-	// 			eprintln!("  Using cached {:?}", database_key.debug(self));
+	// 			log::trace!("  Using cached {:?}", database_key.debug(self));
 	// 		}
 	// 		_ => (),
 	// 	}

--- a/crates/shackle/src/error.rs
+++ b/crates/shackle/src/error.rs
@@ -526,3 +526,21 @@ pub enum ShackleError {
 	#[error("Internal Error - Please report this issue to the Shackle developers")]
 	InternalError(#[from] InternalError),
 }
+
+/// Unable to convert an empty vector into a ShackleError
+#[derive(Error, Debug, Diagnostic, PartialEq, Eq, Clone)]
+#[error("Unable to convert empty vector to a ShackleError")]
+#[diagnostic(code(shackle::empty_error_vec))]
+pub struct EmptyErrorVec;
+
+impl TryFrom<Vec<ShackleError>> for ShackleError {
+	type Error = EmptyErrorVec;
+
+	fn try_from(value: Vec<ShackleError>) -> Result<Self, Self::Error> {
+		match value.len() {
+			0 => Err(EmptyErrorVec),
+			1 => Ok(value.last().unwrap().clone()),
+			_ => Ok(MultipleErrors { errors: value }.into()),
+		}
+	}
+}

--- a/crates/shackle/src/hir/db.rs
+++ b/crates/shackle/src/hir/db.rs
@@ -180,6 +180,28 @@ fn variable_type_map(db: &dyn Hir) -> Arc<FxHashMap<Identifier, Ty>> {
 				result.insert(declaration.data[ident].identifier().unwrap(), ty);
 			}
 		}
+		for (idx, solve) in model.solves.iter() {
+			let types = db.lookup_item_types(ItemRef::new(db, *m, idx));
+			let ident = Identifier::new("_objective", db);
+			let pattern_ty = match solve.goal {
+				super::Goal::Satisfy => None,
+				super::Goal::Maximize {
+					pattern,
+					objective: _,
+				} => Some(types.get_pattern(pattern).unwrap()),
+				super::Goal::Minimize {
+					pattern,
+					objective: _,
+				} => Some(types.get_pattern(pattern).unwrap()),
+			};
+			match &pattern_ty {
+				Some(PatternTy::Variable(ty)) => {
+					result.insert(ident, *ty);
+				}
+				Some(_) => unreachable!(),
+				None => {}
+			};
+		}
 	}
 	Arc::new(result)
 }

--- a/crates/shackle/src/legacy/mod.rs
+++ b/crates/shackle/src/legacy/mod.rs
@@ -40,7 +40,7 @@ fn flatten_array(
 	}
 }
 
-pub fn deserialize_legacy_value(
+fn deserialize_legacy_value(
 	db: &CompilerDatabase,
 	ty: Ty,
 	val: serde_json::Value,
@@ -77,13 +77,13 @@ pub fn deserialize_legacy_value(
 				}
 			} else {
 				assert!(v.is_i64());
-				if let TyData::Integer(_, _) = ty.lookup(db) {
-					Ok(Value::Integer(v.as_i64().unwrap()))
-				} else {
-					Err(InternalError::new(format!(
+				match ty.lookup(db) {
+					TyData::Integer(_, _) => Ok(Value::Integer(v.as_i64().unwrap())),
+					TyData::Float(_, _) => Ok(Value::Float(v.as_i64().unwrap() as f64)),
+					_ => Err(InternalError::new(format!(
 						"legacy interpreter returned a integer value for variable of type `{}'",
 						ty.pretty_print(db)
-					)))
+					))),
 				}
 			}
 		}

--- a/crates/shackle/src/legacy/mod.rs
+++ b/crates/shackle/src/legacy/mod.rs
@@ -1,0 +1,373 @@
+use std::{
+	collections::BTreeMap,
+	io::{BufRead, BufReader},
+	ops::Range,
+	process::{Command, Stdio},
+};
+
+use serde_json::Map;
+
+use crate::{
+	db::CompilerDatabase,
+	error::InternalError,
+	hir::{db::Hir, Identifier},
+	ty::{Ty, TyData},
+	Message, Program, Status, Value,
+};
+
+fn flatten_array(
+	db: &CompilerDatabase,
+	content: &mut Vec<Value>,
+	arr: serde_json::Value,
+	ndim: usize,
+	elem_ty: Ty,
+) -> Result<(), InternalError> {
+	if let serde_json::Value::Array(vec) = arr {
+		if ndim > 1 {
+			for sub_arr in vec {
+				flatten_array(db, content, sub_arr, ndim - 1, elem_ty)?;
+			}
+		} else {
+			for elem in vec {
+				content.push(deserialize_legacy_value(db, elem_ty, elem)?);
+			}
+		}
+		Ok(())
+	} else {
+		Err(InternalError::new(
+			"value from legacy interpreter does not have the expected number of dimensions",
+		))
+	}
+}
+
+pub fn deserialize_legacy_value(
+	db: &CompilerDatabase,
+	ty: Ty,
+	val: serde_json::Value,
+) -> Result<Value, InternalError> {
+	match val {
+		serde_json::Value::Null => {
+			if ty.known_occurs(db) {
+				Err(InternalError::new(
+					format!("legacy interpreter returned an absent value for variable with a type `{}',  known to occur", ty.pretty_print(db)),
+				))
+			} else {
+				Ok(Value::Absent)
+			}
+		}
+		serde_json::Value::Bool(b) => {
+			if let TyData::Boolean(_, _) = ty.lookup(db) {
+				Ok(Value::Boolean(b))
+			} else {
+				Err(InternalError::new(format!(
+					"legacy interpreter returned a Boolean value for variable of type `{}'",
+					ty.pretty_print(db)
+				)))
+			}
+		}
+		serde_json::Value::Number(v) => {
+			if v.is_f64() {
+				if let TyData::Float(_, _) = ty.lookup(db) {
+					Ok(Value::Float(v.as_f64().unwrap()))
+				} else {
+					Err(InternalError::new(format!(
+						"legacy interpreter returned a floating point value for variable of type `{}'",
+						ty.pretty_print(db)
+					)))
+				}
+			} else {
+				assert!(v.is_i64());
+				if let TyData::Integer(_, _) = ty.lookup(db) {
+					Ok(Value::Integer(v.as_i64().unwrap()))
+				} else {
+					Err(InternalError::new(format!(
+						"legacy interpreter returned a integer value for variable of type `{}'",
+						ty.pretty_print(db)
+					)))
+				}
+			}
+		}
+		serde_json::Value::String(v) => {
+			if let TyData::String(_) = ty.lookup(db) {
+				Ok(Value::String(v))
+			} else {
+				Err(InternalError::new(format!(
+					"legacy interpreter returned a String value for variable of type `{}'",
+					ty.pretty_print(db)
+				)))
+			}
+		}
+		serde_json::Value::Array(v) => match ty.lookup(db) {
+			TyData::Array {
+				opt: _,
+				dim,
+				element,
+			} => {
+				if let TyData::Tuple(_, tt) = dim.lookup(db) {
+					// Determine the index sets of the array
+					// FIXME should be returned from the model
+					let mut ranges = Vec::with_capacity(tt.len());
+					let arr = serde_json::Value::Array(v);
+					let mut ii = &arr;
+					while let serde_json::Value::Array(v) = ii {
+						ranges.push(1..(v.len() + 1) as i64);
+						if let Some(fst) = v.last() {
+							ii = fst;
+						} else {
+							ranges.push(1..1);
+						}
+					}
+					// Flatten content
+					let mut content = Vec::new();
+					flatten_array(db, &mut content, arr, tt.len(), element)?;
+
+					Ok(Value::Array(ranges, content))
+				} else {
+					let range: Range<i64> = 1..(v.len() + 1) as i64;
+					let content = v
+						.into_iter()
+						.map(|val| deserialize_legacy_value(db, element, val))
+						.collect::<Result<Vec<_>, _>>()?;
+					Ok(Value::Array(vec![range], content))
+				}
+			}
+			TyData::Tuple(_, types) => {
+				assert_eq!(types.len(), v.len());
+				v.into_iter()
+					.zip(types.iter())
+					.map(|(val, ty)| deserialize_legacy_value(db, *ty, val))
+					.collect::<Result<Vec<_>, _>>()
+					.map(Value::Tuple)
+			}
+			_ => Err(InternalError::new(format!(
+				"legacy interpreter returned a Array value for variable of type `{}'",
+				ty.pretty_print(db)
+			))),
+		},
+		serde_json::Value::Object(mut obj) => match ty.lookup(db) {
+			TyData::Enum(_, _, _) => {
+				let e = if let Some(s) = obj["e"].as_str() {
+					String::from(s)
+				} else if let Some(x) = obj["e"].as_i64() {
+					x.to_string()
+				} else if let Value::Enum(s) = deserialize_legacy_value(db, ty, obj["e"].clone())? {
+					s
+				} else {
+					return Err(InternalError::new(format!(
+						"lagacy interpreter returned an invalid enum value `{:?}'",
+						obj
+					)));
+				};
+				Ok(if obj.contains_key("c") {
+					assert_eq!(obj.len(), 2);
+					Value::Enum(format!("{}({})", obj["c"].as_str().unwrap(), e))
+				} else if obj.contains_key("i") {
+					assert_eq!(obj.len(), 2);
+					Value::Enum(format!("to_enum({}, {})", e, obj["i"].as_i64().unwrap()))
+				} else {
+					assert_eq!(obj.len(), 1);
+					Value::Enum(e)
+				})
+			}
+			TyData::Set(_, _, elem) => {
+				let set = obj.remove("set").unwrap();
+				if let serde_json::Value::Array(set) = set {
+					match elem.lookup(db) {
+						TyData::Integer(_, _) if matches!(set[0], serde_json::Value::Array(_)) => {
+							let mut content = Vec::new();
+							for mem in set {
+								if let serde_json::Value::Array(x) = mem {
+									assert_eq!(x.len(), 2);
+									for i in x[0].as_i64().unwrap()..=x[1].as_i64().unwrap() {
+										content.push(Value::Integer(i))
+									}
+								} else {
+									return Err(InternalError::new(format!(
+										"legacy interpreter invalid range in set members `{}'",
+										mem
+									)));
+								}
+							}
+							Ok(Value::Set(content))
+						}
+						_ => {
+							let content = set
+								.into_iter()
+								.map(|v| deserialize_legacy_value(db, elem, v))
+								.collect::<Result<Vec<_>, _>>()?;
+							Ok(Value::Set(content))
+						}
+					}
+				} else {
+					Err(InternalError::new(format!(
+						"legacy interpreter returned invalid set members `{}'",
+						set
+					)))
+				}
+			}
+			TyData::Record(_, types) => {
+				assert_eq!(types.len(), obj.len());
+				let mut rec = BTreeMap::new();
+				for (name, tt) in types.iter() {
+					let name = name.value(db);
+					let val = deserialize_legacy_value(db, *tt, obj.remove(&name).unwrap())?;
+					rec.insert(name, val);
+				}
+				Ok(Value::Record(rec))
+			}
+			_ => Err(InternalError::new(format!(
+				"legacy interpreter returned a Object value for variable of type `{}'",
+				ty.pretty_print(db)
+			))),
+		},
+	}
+}
+
+impl Program {
+	/// Run the program in the current state
+	/// Solutions are emitted to the callback, and the resulting status is returned.
+	pub fn run<F: Fn(&Message) -> bool>(&mut self, msg_callback: F) -> Status {
+		let mut cmd = Command::new("minizinc");
+		cmd.stdin(Stdio::null())
+			.stdout(Stdio::piped())
+			.stderr(Stdio::null())
+			.arg(self.code.path())
+			.args([
+				"--output-mode",
+				"json",
+				"--json-stream",
+				"--output-time",
+				"--output-objective",
+				"--output-output-item",
+				"--intermediate-solutions",
+				"--solver",
+				self.slv.ident.as_str(),
+			]);
+		if let Some(time_limit) = self.time_limit {
+			cmd.args(["--time-limit", time_limit.as_millis().to_string().as_str()]);
+		}
+		if self.enable_stats {
+			cmd.arg("--statistics");
+		}
+
+		let mut child = cmd.spawn().unwrap(); // TODO: fix unwrap
+		let stdout = child.stdout.take().unwrap();
+
+		let ty_map = self.db.variable_type_map();
+		let mut status = Status::Unknown;
+		for line in BufReader::new(stdout).lines() {
+			match line {
+				Err(err) => {
+					return Status::Err(
+						InternalError::new(format!("minizinc output error: {}", err)).into(),
+					);
+				}
+				Ok(line) => {
+					let mut obj = serde_json::from_str::<Map<String, serde_json::Value>>(&line)
+						.expect("bad message in mzn json");
+					let ty = obj["type"].as_str().expect("bad type field in mzn json");
+					match ty {
+						"statistics" => {
+							if let serde_json::Value::Object(map) = &obj["statistics"] {
+								msg_callback(&Message::Statistic(map));
+							} else {
+								return Status::Err(
+									InternalError::new(format!(
+										"minizinc invalid statistics message: {}",
+										obj["statistics"]
+									))
+									.into(),
+								);
+							}
+						}
+						"solution" => {
+							let mut sol = BTreeMap::new();
+							if let serde_json::Value::Object(map) = obj["output"]
+								.as_object_mut()
+								.unwrap()
+								.remove("json")
+								.unwrap()
+							{
+								for (k, v) in map {
+									let ident = Identifier::new(&k, &self.db);
+									let ty = ty_map[&ident];
+
+									let val = match deserialize_legacy_value(&self.db, ty, v) {
+										Ok(val) => val,
+										Err(e) => return Status::Err(e.into()),
+									};
+									sol.insert(k, val);
+								}
+							} else {
+								panic!("invalid output.json field in mzn json")
+							}
+							msg_callback(&Message::Solution(sol));
+							if let Status::Unknown = status {
+								status = Status::Satisfied;
+							}
+						}
+						"status" => match obj["status"]
+							.as_str()
+							.expect("bad status field in mzn json")
+						{
+							"ALL_SOLUTIONS" => status = Status::AllSolutions,
+							"OPTIMAL_SOLUTION" => status = Status::Optimal,
+							"UNSATISFIABLE" => status = Status::Infeasible,
+							"UNBOUNDED" => todo!(),
+							"UNSAT_OR_UNBOUNDED" => todo!(),
+							"UNKNOWN" => status = Status::Unknown,
+							"ERROR" => {
+								status = Status::Err(
+									InternalError::new(
+										"Error occurred, but no message was provided",
+									)
+									.into(),
+								)
+							}
+							s => {
+								return Status::Err(
+									InternalError::new(format!(
+										"minizinc unknown status type: {}",
+										s
+									))
+									.into(),
+								);
+							}
+						},
+						"error" => {
+							return Status::Err(
+								InternalError::new(format!("minizinc error: {}", obj["message"]))
+									.into(),
+							);
+						}
+						"warning" => {
+							msg_callback(&Message::Warning(
+								obj["message"]
+									.as_str()
+									.expect("invalid message field in mzn json object"),
+							));
+						}
+						s => {
+							return Status::Err(
+								InternalError::new(format!("minizinc unknown message type: {}", s))
+									.into(),
+							);
+						}
+					}
+				}
+			}
+		}
+		match child.wait() {
+			Ok(code) => {
+				if !code.success() {
+					log::warn!(
+						"The MiniZinc process terminated with exit code {}",
+						code.code().unwrap()
+					)
+				};
+				status
+			}
+			Err(e) => Status::Err(InternalError::new(format!("process error: {}", e)).into()),
+		}
+	}
+}

--- a/crates/shackle/src/legacy/mod.rs
+++ b/crates/shackle/src/legacy/mod.rs
@@ -236,6 +236,7 @@ impl Program {
 				"--output-mode",
 				"json",
 				"--json-stream",
+				"--ignore-stdlib",
 				"--output-time",
 				"--output-objective",
 				"--output-output-item",

--- a/crates/shackle/src/lib.rs
+++ b/crates/shackle/src/lib.rs
@@ -9,15 +9,15 @@ pub mod db;
 pub mod error;
 pub mod file;
 pub mod hir;
+mod legacy;
 pub mod syntax;
 pub mod thir;
 pub mod ty;
 pub mod utils;
 
-use db::{FileReader, Inputs};
-use error::{FileError, InternalError, MultipleErrors, ShackleError};
+use db::{CompilerDatabase, FileReader, Inputs};
+use error::{FileError, MultipleErrors, ShackleError};
 use file::{FileRefData, InputFile};
-use serde::de::{Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde_json::Map;
 use tempfile::{Builder, NamedTempFile};
 
@@ -25,10 +25,9 @@ use std::{
 	collections::BTreeMap,
 	env,
 	fmt::{self, Display},
-	io::{BufRead, BufReader, Write},
+	io::Write,
 	ops::Range,
 	path::{Path, PathBuf},
-	process::{Command, Stdio},
 	sync::Arc,
 	time::{Duration, Instant},
 };
@@ -155,6 +154,7 @@ impl Model {
 				})?;
 		}
 		Ok(Program {
+			db,
 			slv: slv.clone(),
 			code: output,
 			enable_stats: false,
@@ -182,6 +182,7 @@ impl Solver {
 
 /// Structure to capture the result of succesful compilation of a Model object
 pub struct Program {
+	db: CompilerDatabase,
 	slv: Solver,
 	code: NamedTempFile,
 	enable_stats: bool,
@@ -204,39 +205,6 @@ pub enum Status {
 	Err(ShackleError),
 }
 
-/// Intermediate messages emitted by shackle in processing and solving a program
-pub enum Message<'a> {
-	/// (Intermediate) solution emitted in the process
-	Solution(BTreeMap<String, Value>),
-	/// Statistical information of the shackle or solving process
-	Statistic(&'a Map<String, serde_json::Value>),
-	/// Trace messages emitted during the shackle process
-	Trace(&'a str),
-	/// Warning messages emitted by shackle or the solver
-	Warning(&'a str),
-}
-
-impl<'a> Display for Message<'a> {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self {
-			Message::Solution(sol) => {
-				for (name, val) in sol {
-					writeln!(f, "{} = {};", name, val)?;
-				}
-				writeln!(f, "----------")
-			}
-			Message::Statistic(map) => {
-				for (name, val) in *map {
-					writeln!(f, "%%%mzn-stat: {}={}", name, val)?;
-				}
-				writeln!(f, "%%%mzn-stat-end")
-			}
-			Message::Trace(msg) => write!(f, "% mzn-trace: {}", msg),
-			Message::Warning(msg) => write!(f, "% WARNING: {}", msg),
-		}
-	}
-}
-
 /// Value types that can be part of a Solution
 pub enum Value {
 	/// Absence of an optional value
@@ -250,6 +218,7 @@ pub enum Value {
 	/// String
 	String(String),
 	/// Identifier of a value of an enumerated type
+	// FIXME this should probably have the actual structuring of enumerated types
 	Enum(String),
 	/// An array of values
 	/// All values are of the same type
@@ -350,143 +319,36 @@ impl Display for Value {
 	}
 }
 
-struct ValueVisitor;
-impl<'de> Visitor<'de> for ValueVisitor {
-	type Value = Value;
-
-	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-		formatter.write_str("MiniZinc Value")
-	}
-	fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
-		Ok(Value::Absent)
-	}
-	fn visit_some<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
-		deserializer.deserialize_any(Self)
-	}
-	fn visit_bool<E: serde::de::Error>(self, v: bool) -> Result<Self::Value, E> {
-		Ok(Value::Boolean(v))
-	}
-	fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
-		Ok(Value::Integer(v))
-	}
-	fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
-		Ok(Value::Integer(v.try_into().unwrap()))
-	}
-	fn visit_f64<E: serde::de::Error>(self, v: f64) -> Result<Self::Value, E> {
-		Ok(Value::Float(v))
-	}
-	fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
-		Ok(Value::String(String::from(v)))
-	}
-	fn visit_seq<V: SeqAccess<'de>>(self, mut seq: V) -> Result<Self::Value, V::Error> {
-		let mut vec: Vec<Value> = Vec::with_capacity(seq.size_hint().unwrap_or(0));
-		while let Some(el) = seq.next_element()? {
-			vec.push(el);
-		}
-		Ok(Value::Tuple(vec))
-	}
-
-	fn visit_map<V: MapAccess<'de>>(self, mut map: V) -> Result<Self::Value, V::Error> {
-		let ret = match map.next_key()? {
-			Some("c") => {
-				let func: &str = map.next_value()?;
-				match map.next_key()? {
-					Some("e") => {
-						let val: Value = map.next_value()?;
-						Ok(Value::Enum(format!("{func}({val})")))
-					}
-					Some(key) => Err(serde::de::Error::unknown_field(key, &["e"])),
-					None => Err(serde::de::Error::missing_field("e")),
-				}
-			}
-			Some("i") => {
-				let val: i64 = map.next_value()?;
-				match map.next_key()? {
-					Some("e") => {
-						let name: &str = map.next_value()?;
-						Ok(Value::Enum(format!("to_enum({name}, {val})")))
-					}
-					Some(key) => Err(serde::de::Error::unknown_field(key, &["e"])),
-					None => Err(serde::de::Error::missing_field("e")),
-				}
-			}
-			Some("e") => {
-				let val = map.next_value()?;
-				match map.next_key()? {
-					Some("i") => {
-						if let Value::String(val) = val {
-							let ival: i64 = map.next_value()?;
-							Ok(Value::Enum(format!("to_enum({val}, {ival})")))
-						} else {
-							Err(serde::de::Error::custom("non-string enum identifier"))
-						}
-					}
-					Some("c") => {
-						let func: &str = map.next_value()?;
-						Ok(Value::Enum(format!("{func}({val})")))
-					}
-					Some(field) => Err(serde::de::Error::unknown_field(field, &["i", "c"])),
-					None => {
-						if let Value::String(e) = val {
-							Ok(Value::Enum(e))
-						} else {
-							Err(serde::de::Error::custom("non-string enum identifier"))
-						}
-					}
-				}
-			}
-			Some("indices") => {
-				let idx: Vec<(i64, i64)> = map.next_value()?;
-				match map.next_key()? {
-					Some("members") => {
-						let members = map.next_value()?;
-						Ok(Value::Array(
-							idx.iter().map(|r| r.0..(r.1 + 1)).collect(),
-							members,
-						))
-					}
-					Some(field) => Err(serde::de::Error::unknown_field(field, &["members"])),
-					None => Err(serde::de::Error::missing_field("members")),
-				}
-			}
-			Some("members") => {
-				let members = map.next_value()?;
-				match map.next_key()? {
-					Some("indices") => {
-						let idx = map.next_value()?;
-						Ok(Value::Array(idx, members))
-					}
-					Some(field) => Err(serde::de::Error::unknown_field(field, &["indices"])),
-					None => Err(serde::de::Error::missing_field("indices")),
-				}
-			}
-			Some("set") => {
-				// FIXME: Only works for integer sets
-				let ranges: Vec<(i64, i64)> = map.next_value()?;
-				let members = ranges
-					.iter()
-					.flat_map(|range| (range.0..=range.1))
-					.map(Value::Integer)
-					.collect();
-				Ok(Value::Set(members))
-			}
-			Some("record") => Ok(Value::Record(map.next_value()?)),
-			_ => Err(serde::de::Error::invalid_length(
-				0,
-				&"object of size 1 or 2",
-			)),
-		};
-		if let Some(key) = map.next_key()? {
-			Err(serde::de::Error::unknown_field(key, &[]))
-		} else {
-			ret
-		}
-	}
+/// Intermediate messages emitted by shackle in processing and solving a program
+pub enum Message<'a> {
+	/// (Intermediate) solution emitted in the process
+	Solution(BTreeMap<String, Value>),
+	/// Statistical information of the shackle or solving process
+	Statistic(&'a Map<String, serde_json::Value>),
+	/// Trace messages emitted during the shackle process
+	Trace(&'a str),
+	/// Warning messages emitted by shackle or the solver
+	Warning(&'a str),
 }
 
-impl<'de> Deserialize<'de> for Value {
-	fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-		deserializer.deserialize_option(ValueVisitor)
+impl<'a> Display for Message<'a> {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Message::Solution(sol) => {
+				for (name, val) in sol {
+					writeln!(f, "{} = {};", name, val)?;
+				}
+				writeln!(f, "----------")
+			}
+			Message::Statistic(map) => {
+				for (name, val) in *map {
+					writeln!(f, "%%%mzn-stat: {}={}", name, val)?;
+				}
+				writeln!(f, "%%%mzn-stat-end")
+			}
+			Message::Trace(msg) => write!(f, "% mzn-trace: {}", msg),
+			Message::Warning(msg) => write!(f, "% WARNING: {}", msg),
+		}
 	}
 }
 
@@ -500,142 +362,6 @@ impl Program {
 	pub fn with_time_limit(mut self, dur: Duration) -> Self {
 		self.time_limit = Some(dur);
 		self
-	}
-
-	/// Run the program in the current state
-	/// Solutions are emitted to the callback, and the resulting status is returned.
-	pub fn run<F: Fn(&Message) -> bool>(&mut self, msg_callback: F) -> Status {
-		let mut cmd = Command::new("minizinc");
-		cmd.stdin(Stdio::null())
-			.stdout(Stdio::piped())
-			.stderr(Stdio::null())
-			.arg(self.code.path())
-			.args([
-				"--output-mode",
-				"typed-json",
-				"--json-stream",
-				"--output-time",
-				"--output-objective",
-				"--output-output-item",
-				"--intermediate-solutions",
-				"--solver",
-				self.slv.ident.as_str(),
-			]);
-		if let Some(time_limit) = self.time_limit {
-			cmd.args(["--time-limit", time_limit.as_millis().to_string().as_str()]);
-		}
-		if self.enable_stats {
-			cmd.arg("--statistics");
-		}
-
-		let mut child = cmd.spawn().unwrap(); // TODO: fix unwrap
-		let stdout = child.stdout.take().unwrap();
-
-		let mut status = Status::Unknown;
-		for line in BufReader::new(stdout).lines() {
-			match line {
-				Err(err) => {
-					return Status::Err(
-						InternalError::new(format!("minizinc output error: {}", err)).into(),
-					);
-				}
-				Ok(line) => {
-					let obj = serde_json::from_str::<Map<String, serde_json::Value>>(&line)
-						.expect("bad message in mzn json");
-					let ty = obj["type"].as_str().expect("bad type field in mzn json");
-					match ty {
-						"statistics" => {
-							if let serde_json::Value::Object(map) = &obj["statistics"] {
-								msg_callback(&Message::Statistic(map));
-							} else {
-								return Status::Err(
-									InternalError::new(format!(
-										"minizinc invalid statistics message: {}",
-										obj["statistics"]
-									))
-									.into(),
-								);
-							}
-						}
-						"solution" => {
-							let mut sol = BTreeMap::new();
-							for (k, v) in obj["output"]["json"]
-								.as_object()
-								.expect("invalid output.json field in mzn json")
-							{
-								let val = v.deserialize_any(ValueVisitor).unwrap_or_else(|_| {
-									panic!("invalid minizinc json value: {:?}", v)
-								});
-								sol.insert(k.clone(), val);
-							}
-							msg_callback(&Message::Solution(sol));
-							if let Status::Unknown = status {
-								status = Status::Satisfied;
-							}
-						}
-						"status" => match obj["status"]
-							.as_str()
-							.expect("bad status field in mzn json")
-						{
-							"ALL_SOLUTIONS" => status = Status::AllSolutions,
-							"OPTIMAL_SOLUTION" => status = Status::Optimal,
-							"UNSATISFIABLE" => status = Status::Infeasible,
-							"UNBOUNDED" => todo!(),
-							"UNSAT_OR_UNBOUNDED" => todo!(),
-							"UNKNOWN" => status = Status::Unknown,
-							"ERROR" => {
-								status = Status::Err(
-									InternalError::new(
-										"Error occurred, but no message was provided",
-									)
-									.into(),
-								)
-							}
-							s => {
-								return Status::Err(
-									InternalError::new(format!(
-										"minizinc unknown status type: {}",
-										s
-									))
-									.into(),
-								);
-							}
-						},
-						"error" => {
-							return Status::Err(
-								InternalError::new(format!("minizinc error: {}", obj["message"]))
-									.into(),
-							);
-						}
-						"warning" => {
-							msg_callback(&Message::Warning(
-								obj["message"]
-									.as_str()
-									.expect("invalid message field in mzn json object"),
-							));
-						}
-						s => {
-							return Status::Err(
-								InternalError::new(format!("minizinc unknown message type: {}", s))
-									.into(),
-							);
-						}
-					}
-				}
-			}
-		}
-		match child.wait() {
-			Ok(code) => {
-				if !code.success() {
-					log::warn!(
-						"The MiniZinc process terminated with exit code {}",
-						code.code().unwrap()
-					)
-				};
-				status
-			}
-			Err(e) => Status::Err(InternalError::new(format!("process error: {}", e)).into()),
-		}
 	}
 }
 

--- a/crates/shackle/src/lib.rs
+++ b/crates/shackle/src/lib.rs
@@ -14,11 +14,23 @@ pub mod thir;
 pub mod ty;
 pub mod utils;
 
-use db::Inputs;
-use error::{MultipleErrors, ShackleError};
-use file::InputFile;
+use db::{FileReader, Inputs};
+use error::{FileError, InternalError, MultipleErrors, ShackleError};
+use file::{FileRefData, InputFile};
+use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
+use serde_json::Map;
+use tempfile::{Builder, NamedTempFile};
 
-use std::{path::Path, sync::Arc, time::Instant};
+use std::{
+	collections::BTreeMap,
+	env,
+	fmt::{self, Display},
+	io::{BufRead, BufReader, Write},
+	path::{Path, PathBuf},
+	process::{Command, Stdio},
+	sync::Arc,
+	time::Instant,
+};
 
 use crate::{
 	hir::db::Hir,
@@ -28,7 +40,7 @@ use crate::{
 /// Shackle error type
 pub type Error = ShackleError;
 /// Result type for Shackle operations
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Parses a list of MiniZinc files given located using the Paths in the vector
 pub fn parse_files(paths: Vec<&Path>) -> Result<()> {
@@ -53,6 +65,482 @@ pub fn parse_files(paths: Vec<&Path>) -> Result<()> {
 		Err(errors.pop().unwrap())
 	} else {
 		Err(MultipleErrors { errors }.into())
+	}
+}
+
+/// Structure used to build a shackle model
+#[derive(Default)]
+pub struct Model {
+	files: Vec<InputFile>,
+	stdlib: Option<PathBuf>,
+}
+
+impl Model {
+	/// Create a Model from the file at the given path
+	pub fn from_file(path: PathBuf) -> Model {
+		Model {
+			files: vec![InputFile::Path(path)],
+			stdlib: None,
+		}
+	}
+
+	/// Create a Model from the given string
+	pub fn from_string(m: String) -> Model {
+		Model {
+			files: vec![InputFile::ModelString(m)],
+			stdlib: None,
+		}
+	}
+
+	/// Compile current model into a Program that can be used by the Shackle interpreter
+	pub fn compile(&self, slv: &Solver) -> Result<Program> {
+		let mut db = db::CompilerDatabase::new();
+		db.set_input_files(Arc::new(self.files.clone()));
+
+		let mut search_dirs = Vec::new();
+		if let Some(path) = &self.stdlib {
+			search_dirs.push(path.clone())
+		} else if let Ok(pathstr) = env::var("MZN_STDLIB_DIR") {
+			search_dirs.push(PathBuf::from(pathstr).join("std"))
+		}
+		db.set_search_directories(Arc::new(search_dirs));
+		let mut errors = (*db.all_diagnostics()).clone();
+		if errors.len() == 1 {
+			return Err(errors.pop().unwrap());
+		}
+		if errors.len() > 1 {
+			return Err(MultipleErrors { errors }.into());
+		}
+		let output = Builder::new()
+			.suffix(".mzn")
+			.tempfile()
+			.map_err(|err| FileError {
+				file: PathBuf::from("tempfile"),
+				message: err.to_string(),
+				other: Vec::new(),
+			})?;
+		for file in db
+			.input_files()
+			.iter()
+			.enumerate()
+			.filter_map(|(idx, f)| match f {
+				InputFile::Path(p) => match p.extension() {
+					Some(e) => {
+						if e.to_str() == Some("mzn") {
+							Some(db.intern_file_ref(FileRefData::InputFile(idx)).into())
+						} else {
+							None
+						}
+					}
+					None => None,
+				},
+				InputFile::ModelString(_) => {
+					Some(db.intern_file_ref(FileRefData::InputFile(idx)).into())
+				}
+				_ => None,
+			}) {
+			let contents = db.file_contents(file)?;
+			output
+				.as_file()
+				.write_all(contents.as_bytes())
+				.map_err(|e| FileError {
+					file: PathBuf::from(output.path()),
+					message: format!("{}", e),
+					other: vec![],
+				})?;
+		}
+		Ok(Program {
+			slv: slv.clone(),
+			code: output,
+		})
+	}
+}
+
+/// Solver specification to compile and solve Model instances.
+#[derive(Clone)]
+pub struct Solver {
+	// TODO: actual information (Load from solver configurations)
+	/// Identifier of the solver
+	ident: String,
+}
+
+impl Solver {
+	/// Lookup a solver specification in default locations that best matches the given identifier
+	pub fn lookup(ident: &str) -> Option<Solver> {
+		Some(Solver {
+			ident: ident.into(),
+		})
+	}
+}
+
+/// Structure to capture the result of succesful compilation of a Model object
+pub struct Program {
+	slv: Solver,
+	code: NamedTempFile,
+}
+
+/// Status of running and solving a Program
+pub enum Status {
+	/// No solutions exist
+	Infeasible,
+	/// A solution has been found
+	Satisfied,
+	/// A solution with the best possible objective value has been found
+	Optimal,
+	/// All possible solutions have been found
+	AllSolutions,
+	/// No result reached within the given limits
+	Unknown,
+	/// An error occurred
+	Err(ShackleError),
+}
+
+/// Intermediate messages emitted by shackle in processing and solving a program
+pub enum Message<'a> {
+	/// (Intermediate) solution emitted in the process
+	Solution(BTreeMap<String, Value>),
+	/// Statistical information of the shackle or solving process
+	Statistic(&'a Map<String, serde_json::Value>),
+	/// Trace messages emitted during the shackle process
+	Trace(&'a str),
+	/// Warning messages emitted by shackle or the solver
+	Warning(&'a str),
+}
+
+impl<'a> Display for Message<'a> {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Message::Solution(sol) => {
+				for (name, val) in sol {
+					writeln!(f, "{} = {};", name, val)?;
+				}
+				writeln!(f, "----------")
+			}
+			Message::Statistic(map) => {
+				for (name, val) in *map {
+					writeln!(f, "%%%mzn-stat: {}={}", name, val)?;
+				}
+				writeln!(f, "%%%mzn-stat-end")
+			}
+			Message::Trace(msg) => write!(f, "% mzn-trace: {}", msg),
+			Message::Warning(msg) => write!(f, "% WARNING: {}", msg),
+		}
+	}
+}
+
+/// Value types that can be part of a Solution
+pub enum Value {
+	/// Absence of an optional value
+	Absent,
+	/// Boolean
+	Boolean(bool),
+	/// Signed integer
+	Integer(i64),
+	/// Floating point
+	Float(f64),
+	/// String
+	String(String),
+	/// Identifier of a value of an enumerated type
+	Enum(String),
+	/// An array of values
+	/// All values are of the same type
+	Array(Vec<Value>),
+	/// A set of values
+	/// All values are of the same type and only occur once
+	Set(Vec<Value>),
+	/// A tuple of values
+	Tuple(Vec<Value>),
+	/// A record of values
+	Record(BTreeMap<String, Value>),
+}
+
+impl<'a> Display for Value {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Value::Absent => write!(f, "<>"),
+			Value::Boolean(v) => write!(f, "{}", v),
+			Value::Integer(v) => write!(f, "{}", v),
+			Value::Float(v) => write!(f, "{}", v),
+			Value::String(v) => write!(f, "{:?}", v),
+			Value::Enum(v) => write!(f, "{}", v),
+			Value::Array(v) => {
+				let mut first = true;
+				write!(f, "[")?;
+				for x in v {
+					if !first {
+						write!(f, ", ")?;
+					}
+					write!(f, "{}", x)?;
+					first = false;
+				}
+				write!(f, "]")
+			}
+			Value::Set(v) => {
+				let mut first = true;
+				write!(f, "{{")?;
+				for x in v {
+					if !first {
+						write!(f, ", ")?;
+					}
+					write!(f, "{}", x)?;
+					first = false;
+				}
+				write!(f, "}}")
+			}
+			Value::Tuple(v) => {
+				let mut first = true;
+				write!(f, "(")?;
+				for x in v {
+					if !first {
+						write!(f, ", ")?;
+					}
+					write!(f, "{}", x)?;
+					first = false;
+				}
+				write!(f, ")")
+			}
+			Value::Record(rec) => {
+				let mut first = true;
+				write!(f, "(")?;
+				for (k, v) in rec {
+					if !first {
+						write!(f, ", ")?;
+					}
+					write!(f, "{}: {}", k, v)?;
+					first = false;
+				}
+				write!(f, ")")
+			}
+		}
+	}
+}
+
+struct ValueVisitor;
+impl<'de> Visitor<'de> for ValueVisitor {
+	type Value = Value;
+
+	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+		formatter.write_str("MiniZinc Value")
+	}
+	fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+		Ok(Value::Absent)
+	}
+	fn visit_some<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+		deserializer.deserialize_any(Self)
+	}
+	fn visit_bool<E: serde::de::Error>(self, v: bool) -> Result<Self::Value, E> {
+		Ok(Value::Boolean(v))
+	}
+	fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
+		Ok(Value::Integer(v))
+	}
+	fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+		Ok(Value::Integer(v.try_into().unwrap()))
+	}
+	fn visit_f64<E: serde::de::Error>(self, v: f64) -> Result<Self::Value, E> {
+		Ok(Value::Float(v))
+	}
+	fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+		Ok(Value::String(String::from(v)))
+	}
+	fn visit_seq<V: SeqAccess<'de>>(self, mut seq: V) -> Result<Self::Value, V::Error> {
+		let mut vec = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+		while let Ok(Some(el)) = seq.next_element() {
+			vec.push(el)
+		}
+		// TODO Detect array
+		Ok(Value::Tuple(vec))
+	}
+
+	// fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+	// where
+	// 	V: MapAccess<'de>,
+	// {
+	// 	let mut secs = None;
+	// 	let mut nanos = None;
+	// 	while let Some(key) = map.next_key()? {
+	// 		match key {
+	// 			Field::Secs => {
+	// 				if secs.is_some() {
+	// 					return Err(de::Error::duplicate_field("secs"));
+	// 				}
+	// 				secs = Some(map.next_value()?);
+	// 			}
+	// 			Field::Nanos => {
+	// 				if nanos.is_some() {
+	// 					return Err(de::Error::duplicate_field("nanos"));
+	// 				}
+	// 				nanos = Some(map.next_value()?);
+	// 			}
+	// 		}
+	// 	}
+	// 	let secs = secs.ok_or_else(|| de::Error::missing_field("secs"))?;
+	// 	let nanos = nanos.ok_or_else(|| de::Error::missing_field("nanos"))?;
+	// 	Ok(Duration::new(secs, nanos))
+	// }
+}
+
+impl<'de> Deserialize<'de> for Value {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		deserializer.deserialize_option(ValueVisitor)
+	}
+}
+
+impl Program {
+	/// Run the program in the current state
+	/// Solutions are emitted to the callback, and the resulting status is returned.
+	pub fn run<F: Fn(&Message) -> bool>(&mut self, msg_callback: F) -> Status {
+		let mut status = Status::Unknown;
+		let mut child = Command::new("minizinc")
+			.args([
+				"--output-mode",
+				"json",
+				"--json-stream",
+				"--output-time",
+				"--output-objective",
+				"--output-output-item",
+				"--intermediate-solutions",
+				"--statistics",
+				"--solver",
+				self.slv.ident.as_str(),
+				self.code.path().to_str().unwrap(), // TODO: fix unwrap
+			])
+			.stdin(Stdio::null())
+			.stdout(Stdio::piped())
+			.stderr(Stdio::null())
+			.spawn()
+			.unwrap(); // TODO: fix unwrap
+		let stdout = child.stdout.take().unwrap();
+
+		for line in BufReader::new(stdout).lines() {
+			match line {
+				Err(err) => {
+					return Status::Err(
+						InternalError::new(format!("minizinc output error: {}", err)).into(),
+					);
+				}
+				Ok(line) => match serde_json::from_str::<Map<String, serde_json::Value>>(&line) {
+					Ok(obj) => {
+						let ty = obj["type"].as_str().expect("bad type field in mzn json");
+						match ty {
+							"statistics" => {
+								if let serde_json::Value::Object(map) = &obj["statistics"] {
+									msg_callback(&Message::Statistic(map));
+								} else {
+									return Status::Err(
+										InternalError::new(format!(
+											"minizinc invalid statistics message: {}",
+											obj["statistics"]
+										))
+										.into(),
+									);
+								}
+							}
+							"solution" => {
+								if let serde_json::Value::Object(map) = &obj["output"]["json"] {
+									let mut sol = BTreeMap::new();
+									for (k, v) in map {
+										let val = v.deserialize_any(ValueVisitor);
+										match val {
+											Ok(val) => {
+												sol.insert(k.clone(), val);
+											}
+											Err(err) => {
+												return Status::Err(
+													InternalError::new(format!(
+														"invalid minizinc json value: {}",
+														err
+													))
+													.into(),
+												);
+											}
+										}
+									}
+									msg_callback(&Message::Solution(sol));
+									if let Status::Unknown = status {
+										status = Status::Satisfied;
+									}
+								} else {
+									return Status::Err(
+										InternalError::new(format!(
+											"minizinc invalid statistics message: {}",
+											obj["statistics"]
+										))
+										.into(),
+									);
+								}
+							}
+							"status" => match obj["status"]
+								.as_str()
+								.expect("bad status field in mzn json")
+							{
+								"ALL_SOLUTIONS" => status = Status::AllSolutions,
+								"OPTIMAL_SOLUTION" => status = Status::Optimal,
+								"UNSATISFIABLE" => status = Status::Infeasible,
+								"UNBOUNDED" => todo!(),
+								"UNSAT_OR_UNBOUNDED" => todo!(),
+								"UNKNOWN" => status = Status::Unknown,
+								"ERROR" => {
+									status = Status::Err(
+										InternalError::new(
+											"Error occurred, but no message was provided",
+										)
+										.into(),
+									)
+								}
+								s => {
+									return Status::Err(
+										InternalError::new(format!(
+											"minizinc unknown status type: {}",
+											s
+										))
+										.into(),
+									);
+								}
+							},
+							"error" => {
+								return Status::Err(
+									InternalError::new(format!(
+										"minizinc error: {}",
+										obj["message"]
+									))
+									.into(),
+								);
+							}
+							s @ _ => {
+								return Status::Err(
+									InternalError::new(format!(
+										"minizinc unknown message type: {}",
+										s
+									))
+									.into(),
+								);
+							}
+						}
+					}
+					Err(err) => {
+						return Status::Err(
+							InternalError::new(format!("minizinc invalid json: {}", err)).into(),
+						);
+					}
+				},
+			}
+		}
+		match child.wait() {
+			Ok(code) => {
+				if !code.success() {
+					log::warn!(
+						"The MiniZinc process terminated with exit code {}",
+						code.code().unwrap()
+					)
+				};
+				status
+			}
+			Err(e) => Status::Err(InternalError::new(format!("process error: {}", e)).into()),
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds a start to the Shackle API, on which the Command-line interface in `shackle-cli` (is now) based, and an integration with the MiniZinc compiler.

This version is merged now as it will improve testing during development, but has some severe limitations. Included that it does not yet accept data files, solvers are not actually managed (the identifier string is just forwarded to legacy interpreter), and the integration with the interpreter still has a lot of rough edges (e.g., if you use a non-development version, or if the solver is not available, then it will just panic).