### PR TITLE
Fix issues in type checking and pretty printing

### DIFF
--- a/crates/shackle/src/db.rs
+++ b/crates/shackle/src/db.rs
@@ -35,6 +35,10 @@ pub trait Inputs {
 	/// Set globals library directory
 	#[salsa::input]
 	fn globals_directory(&self) -> Option<Arc<PathBuf>>;
+
+	/// Set whether to ignore stdlib
+	#[salsa::input]
+	fn ignore_stdlib(&self) -> bool;
 }
 
 /// Queries for compiler settings
@@ -201,6 +205,7 @@ impl CompilerDatabase {
 		db.set_stdlib_directory(stdlib_dir);
 		db.set_globals_directory(None);
 		db.set_search_directories(Arc::new(Vec::new()));
+		db.set_ignore_stdlib(false);
 		db
 	}
 

--- a/crates/shackle/src/hir/pattern.rs
+++ b/crates/shackle/src/hir/pattern.rs
@@ -248,5 +248,6 @@ id_registry!(
 	objective: "_objective",
 	show,
 	eq: "=",
-	index_set
+	index_set,
+	shackle_type,
 );

--- a/crates/shackle/src/thir/db.rs
+++ b/crates/shackle/src/thir/db.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use crate::{db::Upcast, hir::db::Hir};
+use crate::{db::Upcast, hir::db::Hir, Error};
 
 use super::Model;
 
@@ -14,4 +14,8 @@ pub trait Thir: Hir + Upcast<dyn Hir> {
 	/// Lower a model to THIR
 	#[salsa::invoke(super::lower::lower_model)]
 	fn model_thir(&self) -> Arc<Model>;
+
+	/// Check that the pretty printed THIR is a valid model
+	#[salsa::invoke(super::sanity_check::sanity_check_thir)]
+	fn sanity_check_thir(&self) -> Arc<Vec<Error>>;
 }

--- a/crates/shackle/src/thir/mod.rs
+++ b/crates/shackle/src/thir/mod.rs
@@ -14,6 +14,7 @@ pub mod expression;
 pub mod item;
 pub mod lower;
 pub mod pretty_print;
+pub mod sanity_check;
 pub mod source;
 
 use std::ops::Index;

--- a/crates/shackle/src/thir/sanity_check.rs
+++ b/crates/shackle/src/thir/sanity_check.rs
@@ -1,0 +1,32 @@
+//! Sanity checks for THIR.
+//!
+
+use std::sync::Arc;
+
+use crate::{
+	db::{CompilerDatabase, Inputs},
+	file::InputFile,
+	hir::db::Hir,
+	Error,
+};
+
+use super::{db::Thir, pretty_print::PrettyPrinter};
+
+/// Get the diagnostics for running the pretty printed THIR.
+///
+/// This should give no errors (as for the THIR to exist, it must have come
+/// from a valid source program).
+pub fn sanity_check_thir(db: &dyn Thir) -> Arc<Vec<Error>> {
+	let model = db.model_thir();
+
+	// Pretty print with extra info for sanity checking types
+	let mut printer = PrettyPrinter::new(db, &model);
+	printer.old_compat = false;
+	printer.debug_types = true;
+	let code = printer.pretty_print();
+
+	let mut new_db = CompilerDatabase::default();
+	new_db.set_ignore_stdlib(true);
+	new_db.set_input_files(Arc::new(vec![InputFile::ModelString(code)]));
+	new_db.all_diagnostics()
+}

--- a/share/minizinc/std/stdlib/stdlib_ann.mzn
+++ b/share/minizinc/std/stdlib/stdlib_ann.mzn
@@ -638,3 +638,5 @@ annotation mzn_internal_representation;
 /** @group stdlib.annotations.symm_red Indicates that a predicate is a FlatZinc builtin
     and does not need a declaration in the output FlatZinc */
 annotation flatzinc_builtin;
+
+annotation shackle_type(string: ty);


### PR DESCRIPTION
- Ensure callee expressions are correctly typed
- Add `sanity_check_thir` query which runs the pretty printed MiniZinc back through the parser and type checker to ensure it gives the same types that we originally computed