### PR TITLE
Add tests for language server

### DIFF
--- a/crates/shackle-ls/Cargo.toml
+++ b/crates/shackle-ls/Cargo.toml
@@ -18,3 +18,6 @@ threadpool = "1.8.1"
 tree-sitter = "0.20.9"
 tree-sitter-minizinc = { path = "../../parsers/tree-sitter-minizinc" }
 shackle = { path = "../shackle" }
+
+[dev-dependencies]
+expect-test = "1.4.0"

--- a/crates/shackle-ls/src/db.rs
+++ b/crates/shackle-ls/src/db.rs
@@ -1,0 +1,101 @@
+use std::{ops::Deref, path::Path, sync::Arc};
+
+use crossbeam_channel::{SendError, Sender};
+use lsp_server::{Connection, ErrorCode, Message, ResponseError};
+use lsp_types::TextDocumentIdentifier;
+use shackle::{
+	db::{CompilerDatabase, FileReader, HasFileHandler, Inputs},
+	file::{InputFile, ModelRef},
+};
+
+use crate::{diagnostics, vfs::Vfs};
+
+/// Trait for handler preparation
+pub trait LanguageServerContext: Deref<Target = CompilerDatabase> {
+	fn set_active_file_from_document(
+		&mut self,
+		doc: &TextDocumentIdentifier,
+	) -> Result<ModelRef, ResponseError>;
+}
+
+pub struct LanguageServerDatabase {
+	vfs: Vfs,
+	pool: threadpool::ThreadPool,
+	sender: Sender<Message>,
+	db: CompilerDatabase,
+}
+
+impl LanguageServerDatabase {
+	pub fn new(connection: &Connection) -> Self {
+		let fs = Vfs::new();
+		let db = CompilerDatabase::with_file_handler(Box::new(fs.clone()));
+		Self {
+			vfs: fs,
+			pool: threadpool::Builder::new().build(),
+			sender: connection.sender.clone(),
+			db,
+		}
+	}
+
+	pub fn send(&self, message: Message) -> Result<(), SendError<Message>> {
+		self.sender.send(message)
+	}
+
+	pub fn execute_async<F>(&self, f: F)
+	where
+		F: FnOnce(&CompilerDatabase, Sender<Message>) + Send + 'static,
+	{
+		let db = self.db.snapshot();
+		let sender = self.sender.clone();
+		self.pool.execute(move || {
+			f(&db, sender);
+		})
+	}
+
+	pub fn manage_file(&mut self, file: &Path, contents: &str) {
+		log::info!("detected file changed for file {:?}", file);
+		self.vfs.manage_file(file, contents);
+		self.db.on_file_change(file);
+		self.set_active_file(file);
+	}
+
+	pub fn unmanage_file(&mut self, file: &Path) {
+		self.vfs.unmanage_file(file);
+		log::info!("detected file changed for file {:?}", file);
+		self.db.on_file_change(file);
+	}
+
+	pub fn set_active_file(&mut self, path: &Path) {
+		self.db
+			.set_input_files(Arc::new(vec![InputFile::Path(path.to_owned())]));
+		let path_filter = path.to_owned();
+		self.execute_async(move |db, sender| {
+			let notification = diagnostics::diagnostics_notification(db, path_filter.as_path());
+			sender
+				.send(Message::Notification(notification))
+				.expect("Failed to send diagnostics");
+		});
+	}
+}
+
+impl Deref for LanguageServerDatabase {
+	type Target = CompilerDatabase;
+	fn deref(&self) -> &Self::Target {
+		&self.db
+	}
+}
+
+impl LanguageServerContext for LanguageServerDatabase {
+	fn set_active_file_from_document(
+		&mut self,
+		doc: &TextDocumentIdentifier,
+	) -> Result<ModelRef, ResponseError> {
+		let requested_path = doc.uri.to_file_path().map_err(|_| ResponseError {
+			code: ErrorCode::InvalidParams as i32,
+			data: None,
+			message: "Failed to convert URI to file path".to_owned(),
+		})?;
+		self.set_active_file(&requested_path);
+		Ok(self.input_models()[0])
+	}
+}

--- a/crates/shackle-ls/src/diagnostics.rs
+++ b/crates/shackle-ls/src/diagnostics.rs
@@ -37,8 +37,8 @@ fn collect_diagnostic(
 	let span = sc.read_span(first.inner(), 0, 0).ok()?;
 	let range = span_contents_to_range(span.as_ref());
 	let name = span.name()?;
-	let p = PathBuf::from_str(name).ok()?.canonicalize().ok()?;
-	if p.as_path() != path {
+	let p = PathBuf::from_str(name).ok()?;
+	if p != path {
 		return None;
 	}
 	let uri = Url::from_file_path(path).ok()?;

--- a/crates/shackle-ls/src/dispatch.rs
+++ b/crates/shackle-ls/src/dispatch.rs
@@ -5,7 +5,7 @@ use lsp_server::{
 };
 use shackle::db::CompilerDatabase;
 
-use crate::LanguageServerDatabase;
+use crate::{db::LanguageServerContext, LanguageServerDatabase};
 
 enum RequestState<'a> {
 	Unhandled {
@@ -18,7 +18,7 @@ enum RequestState<'a> {
 pub trait RequestHandler<R: lsp_types::request::Request, T> {
 	/// Run on the main thread to prepare the argument passed to the `execute` function.
 	/// Usually needs to call `set_input_files` on the database.
-	fn prepare(db: &mut LanguageServerDatabase, params: R::Params) -> Result<T, ResponseError>;
+	fn prepare(db: &mut impl LanguageServerContext, params: R::Params) -> Result<T, ResponseError>;
 	/// Run in the thread pool. Can panic without crashing the language server.
 	fn execute(db: &CompilerDatabase, data: T) -> Result<R::Result, ResponseError>;
 }

--- a/crates/shackle-ls/src/handlers/goto_definition.rs
+++ b/crates/shackle-ls/src/handlers/goto_definition.rs
@@ -13,14 +13,14 @@ use shackle::{
 	},
 };
 
-use crate::{dispatch::RequestHandler, utils::node_ref_to_location, LanguageServerDatabase};
+use crate::{db::LanguageServerContext, dispatch::RequestHandler, utils::node_ref_to_location};
 
 #[derive(Debug)]
 pub struct GotoDefinitionHandler;
 
 impl RequestHandler<GotoDefinition, (ModelRef, Point)> for GotoDefinitionHandler {
 	fn prepare(
-		db: &mut LanguageServerDatabase,
+		db: &mut impl LanguageServerContext,
 		params: GotoDefinitionParams,
 	) -> Result<(ModelRef, Point), ResponseError> {
 		let model =
@@ -66,5 +66,107 @@ impl RequestHandler<GotoDefinition, (ModelRef, Point)> for GotoDefinitionHandler
 				_ => None,
 			}
 		})())
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use std::str::FromStr;
+
+	use expect_test::expect;
+	use lsp_types::Url;
+
+	use crate::handlers::test::test_handler;
+
+	use super::GotoDefinitionHandler;
+
+	#[test]
+	fn test_goto_definition_1() {
+		test_handler::<GotoDefinitionHandler, _, _>(
+			r#"
+int: hello;
+int: y = hello + 1;
+int: z = hello + let { int: hello = int; } in hello;
+			"#,
+			false,
+			lsp_types::GotoDefinitionParams {
+				partial_result_params: lsp_types::PartialResultParams {
+					partial_result_token: None,
+				},
+				work_done_progress_params: lsp_types::WorkDoneProgressParams {
+					work_done_token: None,
+				},
+				text_document_position_params: lsp_types::TextDocumentPositionParams {
+					text_document: lsp_types::TextDocumentIdentifier {
+						uri: Url::from_str("file:///test.mzn").unwrap(),
+					},
+					position: lsp_types::Position {
+						line: 2,
+						character: 11,
+					},
+				},
+			},
+			expect!([r#"
+    {
+      "Ok": {
+        "uri": "file:///test.mzn",
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 5
+          },
+          "end": {
+            "line": 1,
+            "character": 10
+          }
+        }
+      }
+    }"#]),
+		)
+	}
+
+	#[test]
+	fn test_goto_definition_2() {
+		test_handler::<GotoDefinitionHandler, _, _>(
+			r#"
+int: hello;
+int: y = hello + 1;
+int: z = hello + let { int: hello = int; } in hello;
+			"#,
+			false,
+			lsp_types::GotoDefinitionParams {
+				partial_result_params: lsp_types::PartialResultParams {
+					partial_result_token: None,
+				},
+				work_done_progress_params: lsp_types::WorkDoneProgressParams {
+					work_done_token: None,
+				},
+				text_document_position_params: lsp_types::TextDocumentPositionParams {
+					text_document: lsp_types::TextDocumentIdentifier {
+						uri: Url::from_str("file:///test.mzn").unwrap(),
+					},
+					position: lsp_types::Position {
+						line: 3,
+						character: 48,
+					},
+				},
+			},
+			expect!([r#"
+    {
+      "Ok": {
+        "uri": "file:///test.mzn",
+        "range": {
+          "start": {
+            "line": 3,
+            "character": 28
+          },
+          "end": {
+            "line": 3,
+            "character": 33
+          }
+        }
+      }
+    }"#]),
+		)
 	}
 }

--- a/crates/shackle-ls/src/handlers/hover.rs
+++ b/crates/shackle-ls/src/handlers/hover.rs
@@ -12,14 +12,14 @@ use shackle::{
 	},
 };
 
-use crate::{dispatch::RequestHandler, utils::node_ref_to_location, LanguageServerDatabase};
+use crate::{db::LanguageServerContext, dispatch::RequestHandler, utils::node_ref_to_location};
 
 #[derive(Debug)]
 pub struct HoverHandler;
 
 impl RequestHandler<HoverRequest, (ModelRef, Point)> for HoverHandler {
 	fn prepare(
-		db: &mut LanguageServerDatabase,
+		db: &mut impl LanguageServerContext,
 		params: HoverParams,
 	) -> Result<(ModelRef, Point), ResponseError> {
 		let model =
@@ -84,5 +84,62 @@ impl RequestHandler<HoverRequest, (ModelRef, Point)> for HoverHandler {
 				_ => None,
 			}
 		})())
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use std::str::FromStr;
+
+	use expect_test::expect;
+	use lsp_types::Url;
+
+	use crate::handlers::test::test_handler;
+
+	use super::HoverHandler;
+
+	#[test]
+	fn test_hover() {
+		test_handler::<HoverHandler, _, _>(
+			r#"
+type Foo = tuple(int, int);
+Foo: x;
+any: y = x.1;
+			"#,
+			false,
+			lsp_types::HoverParams {
+				work_done_progress_params: lsp_types::WorkDoneProgressParams {
+					work_done_token: None,
+				},
+				text_document_position_params: lsp_types::TextDocumentPositionParams {
+					text_document: lsp_types::TextDocumentIdentifier {
+						uri: Url::from_str("file:///test.mzn").unwrap(),
+					},
+					position: lsp_types::Position {
+						line: 3,
+						character: 9,
+					},
+				},
+			},
+			expect!([r#"
+    {
+      "Ok": {
+        "contents": {
+          "language": "minizinc",
+          "value": "tuple(int, int)"
+        },
+        "range": {
+          "start": {
+            "line": 3,
+            "character": 9
+          },
+          "end": {
+            "line": 3,
+            "character": 10
+          }
+        }
+      }
+    }"#]),
+		)
 	}
 }

--- a/crates/shackle-ls/src/handlers/mod.rs
+++ b/crates/shackle-ls/src/handlers/mod.rs
@@ -21,3 +21,114 @@ pub use self::view_cst::*;
 pub use self::view_hir::*;
 pub use self::view_pretty_print::*;
 pub use self::view_scope::*;
+
+#[cfg(test)]
+pub mod test {
+	use expect_test::Expect;
+	use lsp_server::ResponseError;
+	use shackle::{
+		db::{CompilerDatabase, FileReader, Inputs},
+		diagnostics::FileError,
+		file::{FileHandler, InputFile},
+	};
+	use std::{
+		ops::Deref,
+		panic::RefUnwindSafe,
+		path::{Path, PathBuf},
+		str::FromStr,
+		sync::Arc,
+	};
+
+	use crate::{db::LanguageServerContext, dispatch::RequestHandler};
+
+	struct MockFileHandler(String);
+
+	impl FileHandler for MockFileHandler {
+		fn durable(&self) -> bool {
+			true
+		}
+
+		fn read_file(&self, path: &Path) -> Result<Arc<String>, FileError> {
+			if path == PathBuf::from_str("test.mzn").unwrap() {
+				return Ok(Arc::new(self.0.clone()));
+			}
+			std::fs::read_to_string(path)
+				.map(Arc::new)
+				.map_err(|err| FileError {
+					file: path.to_path_buf(),
+					message: err.to_string(),
+					other: Vec::new(),
+				})
+		}
+
+		fn snapshot(&self) -> Box<dyn FileHandler + RefUnwindSafe> {
+			unimplemented!()
+		}
+	}
+
+	struct MockDatabase(CompilerDatabase);
+
+	impl Deref for MockDatabase {
+		type Target = CompilerDatabase;
+		fn deref(&self) -> &Self::Target {
+			&self.0
+		}
+	}
+
+	impl LanguageServerContext for MockDatabase {
+		fn set_active_file_from_document(
+			&mut self,
+			_doc: &lsp_types::TextDocumentIdentifier,
+		) -> Result<shackle::file::ModelRef, lsp_server::ResponseError> {
+			Ok(self.input_models()[0])
+		}
+	}
+
+	pub fn run_handler<H, R, T>(
+		model: &str,
+		no_stdlib: bool,
+		params: R::Params,
+	) -> Result<R::Result, ResponseError>
+	where
+		H: RequestHandler<R, T>,
+		R: lsp_types::request::Request,
+	{
+		let mut db = MockDatabase(CompilerDatabase::with_file_handler(Box::new(
+			MockFileHandler(model.to_string()),
+		)));
+		db.0.set_ignore_stdlib(no_stdlib);
+		db.0.set_input_files(Arc::new(vec![InputFile::Path(
+			PathBuf::from_str("test.mzn").unwrap(),
+		)]));
+		H::prepare(&mut db, params).and_then(|t| H::execute(&db, t))
+	}
+
+	/// Test an LSP handler
+	pub fn test_handler<H, R, T>(model: &str, no_stdlib: bool, params: R::Params, expected: Expect)
+	where
+		H: RequestHandler<R, T>,
+		R: lsp_types::request::Request,
+	{
+		let actual = run_handler::<H, R, T>(model, no_stdlib, params);
+		expected.assert_eq(&serde_json::to_string_pretty(&actual).unwrap());
+	}
+
+	/// Test an LSP handler which returns a string
+	pub fn test_handler_display<H, R, T>(
+		model: &str,
+		no_stdlib: bool,
+		params: R::Params,
+		expected: Expect,
+	) where
+		H: RequestHandler<R, T>,
+		R: lsp_types::request::Request,
+		R::Result: std::fmt::Display,
+	{
+		let actual = run_handler::<H, R, T>(model, no_stdlib, params);
+		if let Ok(s) = actual {
+			expected.assert_eq(&s.to_string());
+		} else {
+			expected.assert_eq(&serde_json::to_string_pretty(&actual).unwrap());
+		}
+	}
+}

--- a/crates/shackle-ls/src/handlers/references.rs
+++ b/crates/shackle-ls/src/handlers/references.rs
@@ -11,31 +11,42 @@ use shackle::{
 	syntax::db::SourceParser,
 };
 
-use crate::{dispatch::RequestHandler, utils::node_ref_to_location, LanguageServerDatabase};
+use crate::{db::LanguageServerContext, dispatch::RequestHandler, utils::node_ref_to_location};
 
 #[derive(Debug)]
 pub struct ReferencesHandler;
 
-impl RequestHandler<References, (ModelRef, Point)> for ReferencesHandler {
+#[derive(Debug)]
+pub struct ReferencesHandlerData {
+	model_ref: ModelRef,
+	point: Point,
+	include_decl: bool,
+}
+
+impl RequestHandler<References, ReferencesHandlerData> for ReferencesHandler {
 	fn prepare(
-		db: &mut LanguageServerDatabase,
+		db: &mut impl LanguageServerContext,
 		params: ReferenceParams,
-	) -> Result<(ModelRef, Point), ResponseError> {
-		let model =
+	) -> Result<ReferencesHandlerData, ResponseError> {
+		let model_ref =
 			db.set_active_file_from_document(&params.text_document_position.text_document)?;
-		let start = Point {
+		let point = Point {
 			row: params.text_document_position.position.line as usize,
 			column: params.text_document_position.position.character as usize,
 		};
-		Ok((model, start))
+		Ok(ReferencesHandlerData {
+			model_ref,
+			point,
+			include_decl: params.context.include_declaration,
+		})
 	}
 
 	fn execute(
 		db: &CompilerDatabase,
-		(model_ref, start): (ModelRef, Point),
+		config: ReferencesHandlerData,
 	) -> Result<Option<Vec<Location>>, ResponseError> {
 		Ok((|| {
-			let node = find_node(db, *model_ref, start, start)?;
+			let node = find_node(db, *config.model_ref, config.point, config.point)?;
 			let pattern = match node {
 				NodeRef::Entity(e) => {
 					let item = e.item(db);
@@ -76,7 +87,9 @@ impl RequestHandler<References, (ModelRef, Point)> for ReferencesHandler {
 						let types = db.lookup_item_types(item);
 						let def = match entity.entity(db) {
 							LocalEntityRef::Expression(e) => types.name_resolution(e),
-							LocalEntityRef::Pattern(p) => Some(PatternRef::new(item, p)),
+							LocalEntityRef::Pattern(p) if config.include_decl => {
+								Some(PatternRef::new(item, p))
+							}
 							_ => None,
 						};
 						if def == Some(pattern) {
@@ -89,5 +102,93 @@ impl RequestHandler<References, (ModelRef, Point)> for ReferencesHandler {
 			}
 			Some(locations)
 		})())
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use std::str::FromStr;
+
+	use expect_test::expect;
+	use lsp_types::Url;
+
+	use crate::handlers::test::test_handler;
+
+	use super::ReferencesHandler;
+
+	#[test]
+	fn test_references() {
+		test_handler::<ReferencesHandler, _, _>(
+			r#"
+int: hello;
+int: y = hello + 1;
+int: z = hello + let { int: hello = int; } in hello;
+			"#,
+			false,
+			lsp_types::ReferenceParams {
+				context: lsp_types::ReferenceContext {
+					include_declaration: true,
+				},
+				partial_result_params: lsp_types::PartialResultParams {
+					partial_result_token: None,
+				},
+				work_done_progress_params: lsp_types::WorkDoneProgressParams {
+					work_done_token: None,
+				},
+				text_document_position: lsp_types::TextDocumentPositionParams {
+					text_document: lsp_types::TextDocumentIdentifier {
+						uri: Url::from_str("file:///test.mzn").unwrap(),
+					},
+					position: lsp_types::Position {
+						line: 1,
+						character: 8,
+					},
+				},
+			},
+			expect!([r#"
+    {
+      "Ok": [
+        {
+          "uri": "file:///test.mzn",
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 5
+            },
+            "end": {
+              "line": 1,
+              "character": 10
+            }
+          }
+        },
+        {
+          "uri": "file:///test.mzn",
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 9
+            },
+            "end": {
+              "line": 2,
+              "character": 14
+            }
+          }
+        },
+        {
+          "uri": "file:///test.mzn",
+          "range": {
+            "start": {
+              "line": 3,
+              "character": 9
+            },
+            "end": {
+              "line": 3,
+              "character": 14
+            }
+          }
+        }
+      ]
+    }"#]),
+		)
 	}
 }

--- a/crates/shackle-ls/src/handlers/vfs.rs
+++ b/crates/shackle-ls/src/handlers/vfs.rs
@@ -8,9 +8,7 @@ pub fn on_document_open(db: &mut LanguageServerDatabase, params: DidOpenTextDocu
 		.text_document
 		.uri
 		.to_file_path()
-		.expect("Failed to convert URI to file path")
-		.canonicalize()
-		.expect("Failed to canonicalize path");
+		.expect("Failed to convert URI to file path");
 	db.manage_file(file.as_path(), &params.text_document.text);
 }
 
@@ -19,9 +17,7 @@ pub fn on_document_changed(db: &mut LanguageServerDatabase, params: DidChangeTex
 		.text_document
 		.uri
 		.to_file_path()
-		.expect("Failed to convert URI to file path")
-		.canonicalize()
-		.expect("Failed to canonicalize path");
+		.expect("Failed to convert URI to file path");
 	db.manage_file(
 		file.as_path(),
 		&params
@@ -37,8 +33,6 @@ pub fn on_document_closed(db: &mut LanguageServerDatabase, params: DidCloseTextD
 		.text_document
 		.uri
 		.to_file_path()
-		.expect("Failed to convert URI to file path")
-		.canonicalize()
-		.expect("Failed to canonicalize path");
+		.expect("Failed to convert URI to file path");
 	db.unmanage_file(file.as_path());
 }

--- a/crates/shackle-ls/src/handlers/view_ast.rs
+++ b/crates/shackle-ls/src/handlers/view_ast.rs
@@ -2,14 +2,14 @@ use lsp_server::ResponseError;
 use lsp_types::TextDocumentPositionParams;
 use shackle::{db::CompilerDatabase, file::ModelRef, syntax::db::SourceParser};
 
-use crate::{dispatch::RequestHandler, extensions::ViewAst, LanguageServerDatabase};
+use crate::{db::LanguageServerContext, dispatch::RequestHandler, extensions::ViewAst};
 
 #[derive(Debug)]
 pub struct ViewAstHandler;
 
 impl RequestHandler<ViewAst, ModelRef> for ViewAstHandler {
 	fn prepare(
-		db: &mut LanguageServerDatabase,
+		db: &mut impl LanguageServerContext,
 		params: TextDocumentPositionParams,
 	) -> Result<ModelRef, ResponseError> {
 		db.set_active_file_from_document(&params.text_document)
@@ -19,5 +19,251 @@ impl RequestHandler<ViewAst, ModelRef> for ViewAstHandler {
 			Ok(ast) => Ok(format!("{:#?}", ast)),
 			Err(e) => Ok(e.to_string()),
 		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use std::str::FromStr;
+
+	use expect_test::expect;
+	use lsp_types::Url;
+
+	use crate::handlers::test::test_handler_display;
+
+	use super::ViewAstHandler;
+
+	#[test]
+	fn test_view_ast() {
+		test_handler_display::<ViewAstHandler, _, _>(
+			r#"
+function set of int: foo(int: a, int: b) = a..b;
+int: x = 1;
+var foo(1, 3): y;
+			"#,
+			false,
+			lsp_types::TextDocumentPositionParams {
+				text_document: lsp_types::TextDocumentIdentifier {
+					uri: Url::from_str("file:///test.mzn").unwrap(),
+				},
+				position: lsp_types::Position {
+					line: 0,
+					character: 0,
+				},
+			},
+			expect!([r#"
+    Model {
+        items: [
+            Function(
+                Function {
+                    cst_kind: "function_item",
+                    return_type: SetType(
+                        SetType {
+                            cst_kind: "set_type",
+                            var_type: Par,
+                            opt_type: NonOpt,
+                            element_type: TypeBase(
+                                TypeBase {
+                                    cst_kind: "type_base",
+                                    var_type: None,
+                                    opt_type: None,
+                                    any_type: false,
+                                    domain: Unbounded(
+                                        UnboundedDomain {
+                                            cst_kind: "primitive_type",
+                                            primitive_type: Int,
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    id: UnquotedIdentifier(
+                        UnquotedIdentifier {
+                            cst_kind: "identifier",
+                            name: "foo",
+                        },
+                    ),
+                    parameters: [
+                        Parameter {
+                            cst_kind: "parameter",
+                            declared_type: TypeBase(
+                                TypeBase {
+                                    cst_kind: "type_base",
+                                    var_type: None,
+                                    opt_type: None,
+                                    any_type: false,
+                                    domain: Unbounded(
+                                        UnboundedDomain {
+                                            cst_kind: "primitive_type",
+                                            primitive_type: Int,
+                                        },
+                                    ),
+                                },
+                            ),
+                            pattern: Some(
+                                Identifier(
+                                    UnquotedIdentifier(
+                                        UnquotedIdentifier {
+                                            cst_kind: "identifier",
+                                            name: "a",
+                                        },
+                                    ),
+                                ),
+                            ),
+                            annotations: [],
+                        },
+                        Parameter {
+                            cst_kind: "parameter",
+                            declared_type: TypeBase(
+                                TypeBase {
+                                    cst_kind: "type_base",
+                                    var_type: None,
+                                    opt_type: None,
+                                    any_type: false,
+                                    domain: Unbounded(
+                                        UnboundedDomain {
+                                            cst_kind: "primitive_type",
+                                            primitive_type: Int,
+                                        },
+                                    ),
+                                },
+                            ),
+                            pattern: Some(
+                                Identifier(
+                                    UnquotedIdentifier(
+                                        UnquotedIdentifier {
+                                            cst_kind: "identifier",
+                                            name: "b",
+                                        },
+                                    ),
+                                ),
+                            ),
+                            annotations: [],
+                        },
+                    ],
+                    body: Some(
+                        InfixOperator(
+                            InfixOperator {
+                                cst_kind: "infix_operator",
+                                left: Identifier(
+                                    UnquotedIdentifier(
+                                        UnquotedIdentifier {
+                                            cst_kind: "identifier",
+                                            name: "a",
+                                        },
+                                    ),
+                                ),
+                                operator: Operator {
+                                    cst_kind: "..",
+                                    name: "..",
+                                },
+                                right: Identifier(
+                                    UnquotedIdentifier(
+                                        UnquotedIdentifier {
+                                            cst_kind: "identifier",
+                                            name: "b",
+                                        },
+                                    ),
+                                ),
+                            },
+                        ),
+                    ),
+                    annotations: [],
+                },
+            ),
+            Declaration(
+                Declaration {
+                    cst_kind: "declaration",
+                    pattern: Identifier(
+                        UnquotedIdentifier(
+                            UnquotedIdentifier {
+                                cst_kind: "identifier",
+                                name: "x",
+                            },
+                        ),
+                    ),
+                    declared_type: TypeBase(
+                        TypeBase {
+                            cst_kind: "type_base",
+                            var_type: None,
+                            opt_type: None,
+                            any_type: false,
+                            domain: Unbounded(
+                                UnboundedDomain {
+                                    cst_kind: "primitive_type",
+                                    primitive_type: Int,
+                                },
+                            ),
+                        },
+                    ),
+                    definition: Some(
+                        IntegerLiteral(
+                            IntegerLiteral {
+                                cst_kind: "integer_literal",
+                                value: 1,
+                            },
+                        ),
+                    ),
+                    annotations: [],
+                },
+            ),
+            Declaration(
+                Declaration {
+                    cst_kind: "declaration",
+                    pattern: Identifier(
+                        UnquotedIdentifier(
+                            UnquotedIdentifier {
+                                cst_kind: "identifier",
+                                name: "y",
+                            },
+                        ),
+                    ),
+                    declared_type: TypeBase(
+                        TypeBase {
+                            cst_kind: "type_base",
+                            var_type: Some(
+                                Var,
+                            ),
+                            opt_type: None,
+                            any_type: false,
+                            domain: Bounded(
+                                Call(
+                                    Call {
+                                        cst_kind: "call",
+                                        function: Identifier(
+                                            UnquotedIdentifier(
+                                                UnquotedIdentifier {
+                                                    cst_kind: "identifier",
+                                                    name: "foo",
+                                                },
+                                            ),
+                                        ),
+                                        arguments: [
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    cst_kind: "integer_literal",
+                                                    value: 1,
+                                                },
+                                            ),
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    cst_kind: "integer_literal",
+                                                    value: 3,
+                                                },
+                                            ),
+                                        ],
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    definition: None,
+                    annotations: [],
+                },
+            ),
+        ],
+    }"#]),
+		)
 	}
 }

--- a/crates/shackle-ls/src/handlers/view_cst.rs
+++ b/crates/shackle-ls/src/handlers/view_cst.rs
@@ -2,14 +2,14 @@ use lsp_server::ResponseError;
 use lsp_types::TextDocumentPositionParams;
 use shackle::{db::CompilerDatabase, file::ModelRef, syntax::db::SourceParser};
 
-use crate::{dispatch::RequestHandler, extensions::ViewCst, LanguageServerDatabase};
+use crate::{db::LanguageServerContext, dispatch::RequestHandler, extensions::ViewCst};
 
 #[derive(Debug)]
 pub struct ViewCstHandler;
 
 impl RequestHandler<ViewCst, ModelRef> for ViewCstHandler {
 	fn prepare(
-		db: &mut LanguageServerDatabase,
+		db: &mut impl LanguageServerContext,
 		params: TextDocumentPositionParams,
 	) -> Result<ModelRef, ResponseError> {
 		db.set_active_file_from_document(&params.text_document)
@@ -23,5 +23,94 @@ impl RequestHandler<ViewCst, ModelRef> for ViewCstHandler {
 			}
 			Err(e) => Ok(e.to_string()),
 		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use std::str::FromStr;
+
+	use expect_test::expect;
+	use lsp_types::Url;
+
+	use crate::handlers::test::test_handler_display;
+
+	use super::ViewCstHandler;
+
+	#[test]
+	fn test_view_cst() {
+		test_handler_display::<ViewCstHandler, _, _>(
+			r#"
+function set of int: foo(int: a, int: b) = a..b;
+int: x = 1;
+var foo(1, 3): y;
+			"#,
+			false,
+			lsp_types::TextDocumentPositionParams {
+				text_document: lsp_types::TextDocumentIdentifier {
+					uri: Url::from_str("file:///test.mzn").unwrap(),
+				},
+				position: lsp_types::Position {
+					line: 0,
+					character: 0,
+				},
+			},
+			expect!([r#"
+    kind="source_file", named=true, error=false, missing=false, extra=false, field=None
+      kind="function_item", named=true, error=false, missing=false, extra=false, field=Some("item")
+        kind="function", named=false, error=false, missing=false, extra=false, field=None
+        kind="set_type", named=true, error=false, missing=false, extra=false, field=Some("type")
+          kind="set", named=false, error=false, missing=false, extra=false, field=None
+          kind="of", named=false, error=false, missing=false, extra=false, field=None
+          kind="type_base", named=true, error=false, missing=false, extra=false, field=Some("type")
+            kind="primitive_type", named=true, error=false, missing=false, extra=false, field=Some("domain")
+              kind="int", named=false, error=false, missing=false, extra=false, field=None
+        kind=":", named=false, error=false, missing=false, extra=false, field=None
+        kind="identifier", named=true, error=false, missing=false, extra=false, field=Some("name")
+        kind="(", named=false, error=false, missing=false, extra=false, field=None
+        kind="parameter", named=true, error=false, missing=false, extra=false, field=Some("parameter")
+          kind="type_base", named=true, error=false, missing=false, extra=false, field=Some("type")
+            kind="primitive_type", named=true, error=false, missing=false, extra=false, field=Some("domain")
+              kind="int", named=false, error=false, missing=false, extra=false, field=None
+          kind=":", named=false, error=false, missing=false, extra=false, field=None
+          kind="identifier", named=true, error=false, missing=false, extra=false, field=Some("name")
+        kind=",", named=false, error=false, missing=false, extra=false, field=None
+        kind="parameter", named=true, error=false, missing=false, extra=false, field=Some("parameter")
+          kind="type_base", named=true, error=false, missing=false, extra=false, field=Some("type")
+            kind="primitive_type", named=true, error=false, missing=false, extra=false, field=Some("domain")
+              kind="int", named=false, error=false, missing=false, extra=false, field=None
+          kind=":", named=false, error=false, missing=false, extra=false, field=None
+          kind="identifier", named=true, error=false, missing=false, extra=false, field=Some("name")
+        kind=")", named=false, error=false, missing=false, extra=false, field=None
+        kind="=", named=false, error=false, missing=false, extra=false, field=None
+        kind="infix_operator", named=true, error=false, missing=false, extra=false, field=Some("body")
+          kind="identifier", named=true, error=false, missing=false, extra=false, field=Some("left")
+          kind="..", named=false, error=false, missing=false, extra=false, field=Some("operator")
+          kind="identifier", named=true, error=false, missing=false, extra=false, field=Some("right")
+      kind=";", named=false, error=false, missing=false, extra=false, field=None
+      kind="declaration", named=true, error=false, missing=false, extra=false, field=Some("item")
+        kind="type_base", named=true, error=false, missing=false, extra=false, field=Some("type")
+          kind="primitive_type", named=true, error=false, missing=false, extra=false, field=Some("domain")
+            kind="int", named=false, error=false, missing=false, extra=false, field=None
+        kind=":", named=false, error=false, missing=false, extra=false, field=None
+        kind="identifier", named=true, error=false, missing=false, extra=false, field=Some("name")
+        kind="=", named=false, error=false, missing=false, extra=false, field=None
+        kind="integer_literal", named=true, error=false, missing=false, extra=false, field=Some("definition")
+      kind=";", named=false, error=false, missing=false, extra=false, field=None
+      kind="declaration", named=true, error=false, missing=false, extra=false, field=Some("item")
+        kind="type_base", named=true, error=false, missing=false, extra=false, field=Some("type")
+          kind="var", named=false, error=false, missing=false, extra=false, field=Some("var_par")
+          kind="call", named=true, error=false, missing=false, extra=false, field=Some("domain")
+            kind="identifier", named=true, error=false, missing=false, extra=false, field=Some("function")
+            kind="(", named=false, error=false, missing=false, extra=false, field=None
+            kind="integer_literal", named=true, error=false, missing=false, extra=false, field=Some("argument")
+            kind=",", named=false, error=false, missing=false, extra=false, field=None
+            kind="integer_literal", named=true, error=false, missing=false, extra=false, field=Some("argument")
+            kind=")", named=false, error=false, missing=false, extra=false, field=None
+        kind=":", named=false, error=false, missing=false, extra=false, field=None
+        kind="identifier", named=true, error=false, missing=false, extra=false, field=Some("name")
+      kind=";", named=false, error=false, missing=false, extra=false, field=None
+"#]),
+		)
 	}
 }

--- a/crates/shackle-ls/src/handlers/view_pretty_print.rs
+++ b/crates/shackle-ls/src/handlers/view_pretty_print.rs
@@ -7,14 +7,14 @@ use shackle::{
 	thir::{db::Thir, pretty_print::PrettyPrinter},
 };
 
-use crate::{dispatch::RequestHandler, extensions::ViewPrettyPrint, LanguageServerDatabase};
+use crate::{db::LanguageServerContext, dispatch::RequestHandler, extensions::ViewPrettyPrint};
 
 #[derive(Debug)]
 pub struct ViewPrettyPrintHandler;
 
 impl RequestHandler<ViewPrettyPrint, ModelRef> for ViewPrettyPrintHandler {
 	fn prepare(
-		db: &mut LanguageServerDatabase,
+		db: &mut impl LanguageServerContext,
 		params: TextDocumentPositionParams,
 	) -> Result<ModelRef, ResponseError> {
 		db.set_active_file_from_document(&params.text_document)

--- a/crates/shackle-ls/src/main.rs
+++ b/crates/shackle-ls/src/main.rs
@@ -1,121 +1,26 @@
-use crossbeam_channel::{SendError, Sender};
+use db::LanguageServerDatabase;
 use lsp_types::{
 	notification::{DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument},
 	CompletionOptions, HoverProviderCapability, InitializeParams, OneOf, SemanticTokensFullOptions,
 	SemanticTokensLegend, SemanticTokensOptions, SemanticTokensServerCapabilities,
-	ServerCapabilities, TextDocumentIdentifier, TextDocumentSyncKind,
+	ServerCapabilities, TextDocumentSyncKind,
 };
-use std::ops::Deref;
-use std::sync::Arc;
-use std::{error::Error, path::Path};
+use std::error::Error;
 
-use lsp_server::{Connection, ErrorCode, ExtractError, Message, ResponseError};
-
-use shackle::{
-	db::{CompilerDatabase, FileReader, HasFileHandler, Inputs},
-	file::{InputFile, ModelRef},
-};
+use lsp_server::{Connection, ExtractError, Message};
 
 use crate::{
 	dispatch::{DispatchNotification, DispatchRequest},
 	handlers::*,
 };
 
+mod db;
 mod diagnostics;
 mod dispatch;
 mod extensions;
 mod handlers;
 mod utils;
 mod vfs;
-
-pub struct LanguageServerDatabase {
-	vfs: vfs::Vfs,
-	pool: threadpool::ThreadPool,
-	sender: Sender<Message>,
-	db: CompilerDatabase,
-}
-
-impl LanguageServerDatabase {
-	pub fn new(connection: &Connection) -> Self {
-		let fs = vfs::Vfs::new();
-		let db = CompilerDatabase::with_file_handler(Box::new(fs.clone()));
-		Self {
-			vfs: fs,
-			pool: threadpool::Builder::new().build(),
-			sender: connection.sender.clone(),
-			db,
-		}
-	}
-
-	pub fn send(&self, message: Message) -> Result<(), SendError<Message>> {
-		self.sender.send(message)
-	}
-
-	pub fn execute_async<F>(&self, f: F)
-	where
-		F: FnOnce(&CompilerDatabase, Sender<Message>) + Send + 'static,
-	{
-		let db = self.db.snapshot();
-		let sender = self.sender.clone();
-		self.pool.execute(move || {
-			f(&db, sender);
-		})
-	}
-
-	pub fn manage_file(&mut self, file: &Path, contents: &str) {
-		log::info!("detected file changed for file {:?}", file);
-		self.vfs.manage_file(file, contents);
-		self.db.on_file_change(file);
-		self.set_active_file(file);
-	}
-
-	pub fn unmanage_file(&mut self, file: &Path) {
-		self.vfs.unmanage_file(file);
-		log::info!("detected file changed for file {:?}", file);
-		self.db.on_file_change(file);
-	}
-
-	pub fn set_active_file(&mut self, path: &Path) {
-		self.db
-			.set_input_files(Arc::new(vec![InputFile::Path(path.to_owned())]));
-		let path_filter = path.to_owned();
-		self.execute_async(move |db, sender| {
-			let notification = diagnostics::diagnostics_notification(db, path_filter.as_path());
-			sender
-				.send(Message::Notification(notification))
-				.expect("Failed to send diagnostics");
-		});
-	}
-
-	pub fn set_active_file_from_document(
-		&mut self,
-		doc: &TextDocumentIdentifier,
-	) -> Result<ModelRef, ResponseError> {
-		let requested_path = doc
-			.uri
-			.to_file_path()
-			.map_err(|_| ResponseError {
-				code: ErrorCode::InvalidParams as i32,
-				data: None,
-				message: "Failed to convert URI to file path".to_owned(),
-			})?
-			.canonicalize()
-			.map_err(|_| ResponseError {
-				code: ErrorCode::InvalidParams as i32,
-				data: None,
-				message: "Failed to canonicalise file path".to_owned(),
-			})?;
-		self.set_active_file(&requested_path);
-		Ok(self.input_models()[0])
-	}
-}
-
-impl Deref for LanguageServerDatabase {
-	type Target = CompilerDatabase;
-	fn deref(&self) -> &Self::Target {
-		&self.db
-	}
-}
 
 fn main() -> Result<(), Box<dyn Error + Sync + Send>> {
 	env_logger::Builder::new()

--- a/crates/shackle-ls/src/utils.rs
+++ b/crates/shackle-ls/src/utils.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use lsp_types::Url;
 use miette::{SourceCode, SpanContents};
 use shackle::hir::{db::Hir, ids::NodeRef};
@@ -30,7 +32,9 @@ pub fn node_ref_to_location<T: Into<NodeRef>>(
 ) -> Option<lsp_types::Location> {
 	let (src, span) = node.into().source_span(db);
 	let span_contents = src.read_span(&span, 0, 0).ok()?;
-	let uri = Url::from_file_path(src.path()?).ok()?;
+	let uri = Url::from_file_path(src.path()?)
+		.ok()
+		.or_else(|| Url::from_str(&format!("file:///{}", src.path()?.to_string_lossy())).ok())?;
 	let range = span_contents_to_range(&*span_contents);
 	Some(lsp_types::Location { uri, range })
 }

--- a/crates/shackle/src/file.rs
+++ b/crates/shackle/src/file.rs
@@ -53,7 +53,7 @@ impl SourceFile {
 	/// Create a new source file from a `FileRef`
 	pub fn new(file: FileRef, db: &dyn FileReader) -> Self {
 		Self(SourceFileInner::Text {
-			name: file.path(db).and_then(|p| p.canonicalize().ok()),
+			name: file.path(db),
 			source: file.contents(db).unwrap_or_default(),
 		})
 	}
@@ -145,9 +145,7 @@ impl salsa::InternKey for FileRef {
 impl FileRef {
 	/// Create a new file reference for an external (included) file
 	pub fn new(path: &Path, db: &dyn FileReader) -> Self {
-		db.intern_file_ref(FileRefData::ExternalFile(
-			path.canonicalize().unwrap_or_else(|_| path.to_owned()),
-		))
+		db.intern_file_ref(FileRefData::ExternalFile(path.to_owned()))
 	}
 
 	/// Get the file path if any
@@ -196,7 +194,7 @@ pub fn file_contents(db: &dyn FileReader, file: FileRef) -> Result<Arc<String>, 
 					db.salsa_runtime()
 						.report_synthetic_read(salsa::Durability::LOW);
 				}
-				h.read_file(p.canonicalize().as_ref().unwrap_or(p))
+				h.read_file(p)
 			}
 			InputFile::ModelString(ref s) => Ok(Arc::new(s.clone())),
 			InputFile::DznString(ref s) => Ok(Arc::new(s.clone())),

--- a/crates/shackle/src/hir/db.rs
+++ b/crates/shackle/src/hir/db.rs
@@ -282,10 +282,15 @@ fn resolve_includes(db: &dyn Hir) -> Result<Arc<Vec<ModelRef>>> {
 	// Resolve includes
 	let mut seen = FxHashSet::default();
 	while let Some(file) = todo.pop() {
-		if seen.contains(&file) {
-			continue;
+		if let Some(path) = file
+			.path(db.upcast())
+			.map(|p| p.canonicalize().unwrap_or(p))
+		{
+			if seen.contains(&path) {
+				continue;
+			}
+			seen.insert(path);
 		}
-		seen.insert(file);
 		let model = match db.ast(*file) {
 			Ok(m) => m,
 			Err(e) => {


### PR DESCRIPTION
Adds some basic testing infrastructure to the language server

Also avoids canonicalising paths in most cases since this can cause problems with LSP clients not recognising files which are symlinked.