### PR TITLE
Refactor out identifier printing code

### DIFF
--- a/crates/shackle/src/hir/pattern.rs
+++ b/crates/shackle/src/hir/pattern.rs
@@ -3,6 +3,7 @@
 
 use super::{db::Hir, BooleanLiteral, FloatLiteral, IntegerLiteral, ItemData, StringLiteral};
 use crate::db::{InternedString, InternedStringData};
+use crate::utils::pretty_print_identifier;
 use crate::{arena::ArenaIndex, utils::impl_enum_from};
 
 /// A pattern for destructuring
@@ -150,62 +151,9 @@ impl Identifier {
 	}
 
 	/// Pretty print this identifier (adding quotes if needed)
-	///
-	/// TODO: Don't quote UTF-8
 	pub fn pretty_print(&self, db: &dyn Hir) -> String {
 		let ident = self.lookup(db);
-		let name = ident.as_str();
-		if matches!(
-			name,
-			"ann"
-				| "annotation" | "any"
-				| "array" | "bool"
-				| "case" | "constraint"
-				| "default" | "diff"
-				| "div" | "else" | "elseif"
-				| "endif" | "enum"
-				| "false" | "float"
-				| "function" | "if"
-				| "in" | "include"
-				| "int" | "intersect"
-				| "let" | "list" | "maximize"
-				| "minimize" | "mod"
-				| "not" | "of" | "op"
-				| "opt" | "output"
-				| "par" | "predicate"
-				| "record" | "satisfy"
-				| "set" | "solve"
-				| "string" | "subset"
-				| "superset" | "symdiff"
-				| "test" | "then"
-				| "true" | "tuple"
-				| "type" | "union"
-				| "var" | "where"
-				| "xor"
-		) {
-			return format!("'{}'", name);
-		}
-		for c in name.chars() {
-			if matches!(
-				c,
-				'"' | '\''
-					| '.' | '-' | '[' | ']'
-					| '^' | ',' | ';' | ':'
-					| '(' | ')' | '{' | '}'
-					| '&' | '|' | '$' | '∞'
-					| '%' | '<' | '>' | '⟷'
-					| '⇔' | '→' | '⇒' | '←'
-					| '⇐' | '/' | '∨' | '⊻'
-					| '∧' | '=' | '!' | '≠'
-					| '≤' | '≥' | '∈' | '⊆'
-					| '⊇' | '∪' | '∩' | '+'
-					| '*' | '~'
-			) || c.is_whitespace()
-			{
-				return format!("'{}'", name);
-			}
-		}
-		ident
+		pretty_print_identifier(&ident)
 	}
 }
 

--- a/crates/shackle/src/utils.rs
+++ b/crates/shackle/src/utils.rs
@@ -111,3 +111,87 @@ pub fn levenshtein_distance(s: &str, t: &str) -> usize {
 	}
 	*dp0.last().unwrap()
 }
+
+/// Pretty print an identifier.
+///
+/// Either returns the string as is, if it is already a valid identifier,
+/// otherwise, encloses it in quotes.
+///
+/// Panics if the given name contains a quote.
+pub fn pretty_print_identifier(name: &str) -> String {
+	assert!(
+		!name.contains('\''),
+		"Identifier names cannot contain single quotes"
+	);
+	if matches!(
+		name,
+		"ann"
+			| "annotation"
+			| "any" | "array"
+			| "bool" | "case"
+			| "constraint"
+			| "default" | "diff"
+			| "div" | "else"
+			| "elseif" | "endif"
+			| "enum" | "false"
+			| "float" | "function"
+			| "if" | "in"
+			| "include" | "int"
+			| "intersect"
+			| "let" | "list"
+			| "maximize" | "minimize"
+			| "mod" | "not"
+			| "of" | "op"
+			| "opt" | "output"
+			| "par" | "predicate"
+			| "record" | "satisfy"
+			| "set" | "solve"
+			| "string" | "subset"
+			| "superset" | "symdiff"
+			| "test" | "then"
+			| "true" | "tuple"
+			| "type" | "union"
+			| "var" | "where"
+			| "xor"
+	) {
+		return format!("'{}'", name);
+	}
+
+	for c in name.chars() {
+		if matches!(
+			c,
+			'"' | '\''
+				| '.' | '-' | '['
+				| ']' | '^' | ','
+				| ';' | ':' | '('
+				| ')' | '{' | '}'
+				| '&' | '|' | '$'
+				| '∞' | '%' | '<'
+				| '>' | '⟷' | '⇔'
+				| '→' | '⇒' | '←'
+				| '⇐' | '/' | '∨'
+				| '⊻' | '∧' | '='
+				| '!' | '≠' | '≤'
+				| '≥' | '∈' | '⊆'
+				| '⊇' | '∪' | '∩'
+				| '+' | '*' | '~'
+		) || c.is_whitespace()
+		{
+			return format!("'{}'", name);
+		}
+	}
+	name.to_owned()
+}
+
+#[cfg(test)]
+mod test {
+	use super::pretty_print_identifier;
+
+	#[test]
+	fn pretty_print_ident() {
+		assert_eq!(pretty_print_identifier("x"), "x");
+		assert_eq!(pretty_print_identifier("-"), "'-'");
+		assert_eq!(pretty_print_identifier("a b"), "'a b'");
+		assert_eq!(pretty_print_identifier("😃"), "😃");
+	}
+}


### PR DESCRIPTION
This way it can be reused in the language server