### PR TITLE
Prevent stack overflows due to deeply nested model constructs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,7 @@ jobs:
           rustup default ${{ env.RUST_CHANNEL }}
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
-      - name: Build shackle-cli
+      - name: Build ${{ matrix.crate }}
         run: cargo install --root dist/ --path crates/${{ matrix.crate }}
       - name: Upload build artifact
         uses: actions/upload-artifact@v3

--- a/crates/shackle-ls/src/handlers/view_pretty_print.rs
+++ b/crates/shackle-ls/src/handlers/view_pretty_print.rs
@@ -22,7 +22,10 @@ impl RequestHandler<ViewPrettyPrint, ModelRef> for ViewPrettyPrintHandler {
 	fn execute(db: &CompilerDatabase, _: ModelRef) -> Result<String, ResponseError> {
 		let errors = db.all_errors();
 		if errors.is_empty() {
-			let thir = db.final_thir();
+			let thir = match db.final_thir() {
+				Ok(m) => m,
+				Err(e) => return Ok(format!("%: THIR error: {}", e)),
+			};
 			let printer = PrettyPrinter::new(db, &thir);
 			Ok(printer.pretty_print())
 		} else {

--- a/crates/shackle/Cargo.toml
+++ b/crates/shackle/Cargo.toml
@@ -12,6 +12,7 @@ miette = "5.5.0"
 rustc-hash = "1.1.0"
 salsa = { git = "https://github.com/salsa-rs/salsa" }
 serde_json = "1.0"
+stacker = "0.1.15"
 tempfile = "3.3.0"
 thiserror = "1.0.38"
 tree-sitter = "0.20.9"

--- a/crates/shackle/src/arena.rs
+++ b/crates/shackle/src/arena.rs
@@ -108,6 +108,18 @@ impl<T> Arena<T> {
 		Self::default()
 	}
 
+	/// Create an arena with the given capacity
+	pub fn with_capacity(capacity: u32) -> Arena<T> {
+		Self {
+			items: Vec::with_capacity(capacity as usize),
+		}
+	}
+
+	/// Reserve additional space in the arena
+	pub fn reserve(&mut self, additional: u32) {
+		self.items.reserve(additional as usize);
+	}
+
 	/// Clear the arena.
 	pub fn clear(&mut self) {
 		self.items.clear();
@@ -308,9 +320,9 @@ impl<K, V> ArenaMap<K, V> {
 	}
 
 	/// Create a new arena map with the given capacity
-	pub fn with_capacity(capacity: usize) -> ArenaMap<K, V> {
+	pub fn with_capacity(capacity: u32) -> ArenaMap<K, V> {
 		Self {
-			items: Vec::with_capacity(capacity),
+			items: Vec::with_capacity(capacity as usize),
 			phantom: PhantomData,
 		}
 	}

--- a/crates/shackle/src/diagnostics/error.rs
+++ b/crates/shackle/src/diagnostics/error.rs
@@ -474,6 +474,21 @@ pub struct InvalidNumericLiteral {
 	pub span: SourceSpan,
 }
 
+/// Reached function instantiation recursion limit
+#[derive(Error, Debug, Diagnostic, PartialEq, Eq, Clone)]
+#[error("Function instantiation error")]
+#[diagnostic(code(shackle::instantiation_recursion_limit))]
+pub struct TypeSpecialisationRecursionLimit {
+	/// The source code
+	#[source_code]
+	pub src: SourceFile,
+	/// The function being instantiated
+	pub name: String,
+	/// The span associated with the error
+	#[label("Reached recursion limit while instantiating {name}")]
+	pub span: SourceSpan,
+}
+
 /// Main Shackle error type
 #[derive(Error, Diagnostic, Debug, PartialEq, Eq, Clone)]
 pub enum ShackleError {
@@ -573,6 +588,10 @@ pub enum ShackleError {
 	#[error(transparent)]
 	#[diagnostic(transparent)]
 	InvalidNumericLiteral(#[from] InvalidNumericLiteral),
+	/// Reached function instantiation recursion limit
+	#[error(transparent)]
+	#[diagnostic(transparent)]
+	TypeSpecialisationRecursionLimit(#[from] TypeSpecialisationRecursionLimit),
 	/// An internal error
 	#[error("Internal Error - Please report this issue to the Shackle developers")]
 	InternalError(#[from] InternalError),

--- a/crates/shackle/src/file.rs
+++ b/crates/shackle/src/file.rs
@@ -163,6 +163,13 @@ impl FileRef {
 	pub fn contents(&self, db: &dyn FileReader) -> Result<Arc<String>, FileError> {
 		db.file_contents(*self)
 	}
+
+	/// Pretty print file name for debugging
+	pub fn pretty_print(&self, db: &dyn FileReader) -> String {
+		self.path(db)
+			.map(|p| p.to_string_lossy().to_string())
+			.unwrap_or_else(|| "<unnamed file>".to_owned())
+	}
 }
 
 /// Reference to an input file or external file

--- a/crates/shackle/src/hir/db.rs
+++ b/crates/shackle/src/hir/db.rs
@@ -245,6 +245,8 @@ fn variable_type_map(db: &dyn Hir) -> Arc<FxHashMap<Identifier, Ty>> {
 }
 
 fn resolve_includes(db: &dyn Hir) -> Result<Arc<Vec<ModelRef>>> {
+	log::info!("Resolving includes");
+
 	let mut errors: Vec<Error> = Vec::new();
 	let mut todo = (*db.input_models()).clone();
 
@@ -289,8 +291,10 @@ fn resolve_includes(db: &dyn Hir) -> Result<Arc<Vec<ModelRef>>> {
 			if seen.contains(&path) {
 				continue;
 			}
+			log::info!("Including model {}", path.to_string_lossy());
 			seen.insert(path);
 		}
+
 		let model = match db.ast(*file) {
 			Ok(m) => m,
 			Err(e) => {
@@ -298,6 +302,7 @@ fn resolve_includes(db: &dyn Hir) -> Result<Arc<Vec<ModelRef>>> {
 				continue;
 			}
 		};
+
 		models.push(file);
 		for item in model.items() {
 			if let ast::Item::Include(i) = item {

--- a/crates/shackle/src/hir/ids.rs
+++ b/crates/shackle/src/hir/ids.rs
@@ -307,6 +307,30 @@ impl EntityRef {
 	pub fn entity(&self, db: &dyn Hir) -> LocalEntityRef {
 		db.lookup_intern_entity_ref(*self).1
 	}
+
+	/// Get as an `ExpressionRef` if this is one
+	pub fn as_expression_ref(&self, db: &dyn Hir) -> Option<ExpressionRef> {
+		match self.entity(db) {
+			LocalEntityRef::Expression(e) => Some(ExpressionRef::new(self.item(db), e)),
+			_ => None,
+		}
+	}
+
+	/// Get as an `TypeRef` if this is one
+	pub fn as_type_ref(&self, db: &dyn Hir) -> Option<TypeRef> {
+		match self.entity(db) {
+			LocalEntityRef::Type(t) => Some(TypeRef::new(self.item(db), t)),
+			_ => None,
+		}
+	}
+
+	/// Get as an `PatternRef` if this is one
+	pub fn as_pattern_ref(&self, db: &dyn Hir) -> Option<PatternRef> {
+		match self.entity(db) {
+			LocalEntityRef::Pattern(p) => Some(PatternRef::new(self.item(db), p)),
+			_ => None,
+		}
+	}
 }
 
 impl salsa::InternKey for EntityRef {
@@ -339,6 +363,30 @@ impl_enum_from!(NodeRef::Item(ItemRef));
 impl_enum_from!(NodeRef::Entity(EntityRef));
 
 impl NodeRef {
+	/// Get the inner `ModelRef` if this is one
+	pub fn as_model_ref(&self) -> Option<ModelRef> {
+		match self {
+			NodeRef::Model(m) => Some(*m),
+			_ => None,
+		}
+	}
+
+	/// Get the inner `ItemRef` if this is one
+	pub fn as_item_ref(&self) -> Option<ItemRef> {
+		match self {
+			NodeRef::Item(i) => Some(*i),
+			_ => None,
+		}
+	}
+
+	/// Get the inner `EntityRef` if this is one
+	pub fn as_entity(&self) -> Option<EntityRef> {
+		match self {
+			NodeRef::Entity(e) => Some(*e),
+			_ => None,
+		}
+	}
+
 	/// Get the source and span for emitting a diagnostic
 	pub fn source_span(&self, db: &dyn Hir) -> (SourceFile, SourceSpan) {
 		let model = match *self {

--- a/crates/shackle/src/hir/lower/expression.rs
+++ b/crates/shackle/src/hir/lower/expression.rs
@@ -7,6 +7,7 @@ use crate::{
 	diagnostics::{InvalidArrayLiteral, InvalidNumericLiteral, SyntaxError},
 	hir::source::Origin,
 	syntax::ast::{self, AstNode},
+	utils::maybe_grow_stack,
 	Error,
 };
 
@@ -44,6 +45,10 @@ impl ExpressionCollector<'_> {
 
 	/// Lower an AST expression into HIR
 	pub fn collect_expression(&mut self, expression: ast::Expression) -> ArenaIndex<Expression> {
+		maybe_grow_stack(|| self.collect_expression_inner(expression))
+	}
+
+	fn collect_expression_inner(&mut self, expression: ast::Expression) -> ArenaIndex<Expression> {
 		let origin = Origin::new(&expression);
 		log::debug!(
 			"Lowering {} to HIR ({})",

--- a/crates/shackle/src/hir/lower/item.rs
+++ b/crates/shackle/src/hir/lower/item.rs
@@ -14,13 +14,7 @@ use super::{ExpressionCollector, TypeInstIdentifiers};
 
 /// Lower a model to HIR
 pub fn lower_items(db: &dyn Hir, model: ModelRef) -> (Arc<Model>, Arc<SourceMap>, Arc<Vec<Error>>) {
-	log::info!(
-		"Lowering {} to HIR",
-		model
-			.path(db.upcast())
-			.map(|p| p.to_string_lossy().to_string())
-			.unwrap_or_else(|| "<unnamed file>".to_owned())
-	);
+	log::info!("Lowering {} to HIR", model.pretty_print(db.upcast()));
 	let ast = match db.ast(*model) {
 		Ok(m) => m,
 		Err(e) => return (Default::default(), Default::default(), Arc::new(vec![e])),

--- a/crates/shackle/src/hir/lower/item.rs
+++ b/crates/shackle/src/hir/lower/item.rs
@@ -14,6 +14,13 @@ use super::{ExpressionCollector, TypeInstIdentifiers};
 
 /// Lower a model to HIR
 pub fn lower_items(db: &dyn Hir, model: ModelRef) -> (Arc<Model>, Arc<SourceMap>, Arc<Vec<Error>>) {
+	log::info!(
+		"Lowering {} to HIR",
+		model
+			.path(db.upcast())
+			.map(|p| p.to_string_lossy().to_string())
+			.unwrap_or_else(|| "<unnamed file>".to_owned())
+	);
 	let ast = match db.ast(*model) {
 		Ok(m) => m,
 		Err(e) => return (Default::default(), Default::default(), Arc::new(vec![e])),
@@ -56,6 +63,7 @@ impl ItemCollector<'_> {
 
 	/// Lower an AST item to HIR
 	pub fn collect_item(&mut self, item: ast::Item) {
+		log::debug!("Lowering {} to HIR", item.cst_text());
 		let (it, sm) = match item.clone() {
 			ast::Item::Annotation(a) => self.collect_annotation(a),
 			ast::Item::Assignment(a) => self.collect_assignment(a),
@@ -69,6 +77,7 @@ impl ItemCollector<'_> {
 			ast::Item::Solve(s) => self.collect_solve(s),
 			ast::Item::TypeAlias(t) => self.collect_type_alias(t),
 		};
+		log::debug!("Produced HIR item {:?}", it);
 		self.source_map.insert(it.into(), Origin::new(&item));
 		self.source_map.add_from_item_data(self.db, it, &sm);
 	}

--- a/crates/shackle/src/hir/scope.rs
+++ b/crates/shackle/src/hir/scope.rs
@@ -207,6 +207,12 @@ pub fn collect_global_scope(db: &dyn Hir) -> (Arc<ScopeData>, Arc<Vec<Error>>) {
 			}
 		}
 	}
+	log::info!(
+		"{} atoms, {} variables, {} function names in global scope",
+		scope.variables.len(),
+		scope.atoms.len(),
+		scope.functions.len()
+	);
 	(Arc::new(scope), Arc::new(diagnostics))
 }
 

--- a/crates/shackle/src/hir/typecheck/body.rs
+++ b/crates/shackle/src/hir/typecheck/body.rs
@@ -54,6 +54,20 @@ impl BodyTypeContext {
 		}
 	}
 
+	/// Create a new signature type context with the given capacity for patterns/expressions
+	pub fn with_capacity(item: ItemRef, patterns: u32, expressions: u32) -> Self {
+		Self {
+			item,
+			data: BodyTypes {
+				patterns: ArenaMap::with_capacity(patterns + 1),
+				expressions: ArenaMap::with_capacity(expressions + 1),
+				identifier_resolution: FxHashMap::default(),
+				pattern_resolution: FxHashMap::default(),
+			},
+			diagnostics: Vec::new(),
+		}
+	}
+
 	/// Compute the type of the body of this item
 	pub fn type_item(&mut self, db: &dyn Hir) {
 		let item = self.item;

--- a/crates/shackle/src/hir/typecheck/mod.rs
+++ b/crates/shackle/src/hir/typecheck/mod.rs
@@ -397,6 +397,7 @@ pub fn collect_item_signature(
 	db: &dyn Hir,
 	item: ItemRef,
 ) -> (Arc<SignatureTypes>, Arc<Vec<Error>>) {
+	log::debug!("Type checking signature of {:?}", item);
 	let mut ctx = SignatureTypeContext::new(item);
 	ctx.type_item(db, item);
 	let (s, e) = ctx.finish();
@@ -405,6 +406,7 @@ pub fn collect_item_signature(
 
 /// Type-check expressions in an item (other than those used in the signature)
 pub fn collect_item_body(db: &dyn Hir, item: ItemRef) -> (Arc<BodyTypes>, Arc<Vec<Error>>) {
+	log::debug!("Type checking body of {:?}", item);
 	let mut ctx = BodyTypeContext::new(item);
 	ctx.type_item(db);
 	let (s, e) = ctx.finish();

--- a/crates/shackle/src/hir/typecheck/mod.rs
+++ b/crates/shackle/src/hir/typecheck/mod.rs
@@ -407,7 +407,11 @@ pub fn collect_item_signature(
 /// Type-check expressions in an item (other than those used in the signature)
 pub fn collect_item_body(db: &dyn Hir, item: ItemRef) -> (Arc<BodyTypes>, Arc<Vec<Error>>) {
 	log::debug!("Type checking body of {:?}", item);
-	let mut ctx = BodyTypeContext::new(item);
+	let model = item.model(db);
+	let it = item.local_item_ref(db);
+	let patterns = it.data(&model).patterns.len();
+	let expressions = it.data(&model).expressions.len();
+	let mut ctx = BodyTypeContext::with_capacity(item, patterns, expressions);
 	ctx.type_item(db);
 	let (s, e) = ctx.finish();
 	(Arc::new(s), Arc::new(e))

--- a/crates/shackle/src/hir/typecheck/test.rs
+++ b/crates/shackle/src/hir/typecheck/test.rs
@@ -171,6 +171,7 @@ fn test_type_expressions() {
 		"let { constraint let { var bool: p } in p } in true",
 		expect!("var bool"),
 	);
+	tester.check_expression("(lambda int: (int: x) => x)(1)", expect!("int"));
 }
 
 #[test]

--- a/crates/shackle/src/hir/typecheck/typer.rs
+++ b/crates/shackle/src/hir/typecheck/typer.rs
@@ -20,6 +20,7 @@ use crate::{
 		FunctionEntry, FunctionResolutionError, FunctionType, InstantiationError, OptType, Ty,
 		TyData, VarType,
 	},
+	utils::maybe_grow_stack,
 	Error,
 };
 
@@ -119,6 +120,10 @@ impl<'a, T: TypeContext> Typer<'a, T> {
 
 	/// Get the type of this expression
 	pub fn collect_expression(&mut self, expr: ArenaIndex<Expression>) -> Ty {
+		maybe_grow_stack(|| self.collect_expression_inner(expr))
+	}
+
+	fn collect_expression_inner(&mut self, expr: ArenaIndex<Expression>) -> Ty {
 		let db = self.db;
 		let result = match &self.data[expr] {
 			Expression::Absent => self.types.bottom.make_opt(db.upcast()),

--- a/crates/shackle/src/hir/typecheck/typer.rs
+++ b/crates/shackle/src/hir/typecheck/typer.rs
@@ -338,7 +338,7 @@ impl<'a, T: TypeContext> Typer<'a, T> {
 						);
 						return self.types.error;
 					} else {
-						return ty;
+						return f.return_type;
 					}
 				}
 

--- a/crates/shackle/src/hir/validate.rs
+++ b/crates/shackle/src/hir/validate.rs
@@ -30,6 +30,7 @@ use super::{
 
 /// Validate HIR
 pub fn validate_hir(db: &dyn Hir) -> Arc<Vec<Error>> {
+	log::info!("Validating HIR");
 	let mut diagnostics = Vec::new();
 	// Validate overloading
 	let global_scope = db.lookup_global_scope();

--- a/crates/shackle/src/lib.rs
+++ b/crates/shackle/src/lib.rs
@@ -68,7 +68,10 @@ impl Model {
 	/// Check whether a model contains any (non-runtime) errors
 	pub fn check(&self, _slv: &Solver, _data: &[PathBuf], _complete: bool) -> Vec<Error> {
 		// TODO: Check data files
-		self.db.all_errors().iter().cloned().collect()
+		self.db
+			.run_hir_phase()
+			.map(|_| Vec::new())
+			.unwrap_or_else(|e| e.iter().cloned().collect())
 	}
 
 	/// Compile current model into a Program that can be used by the Shackle interpreter

--- a/crates/shackle/src/lib.rs
+++ b/crates/shackle/src/lib.rs
@@ -80,7 +80,7 @@ impl Model {
 		if !errors.is_empty() {
 			return Err(ShackleError::try_from(errors).unwrap());
 		}
-		let prg_model = self.db.final_thir();
+		let prg_model = self.db.final_thir()?;
 		Ok(Program {
 			db: self.db,
 			slv: slv.clone(),

--- a/crates/shackle/src/thir/db.rs
+++ b/crates/shackle/src/thir/db.rs
@@ -2,7 +2,7 @@
 
 //! Salsa database for THIR operations
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock, RwLockReadGuard};
 
 use crate::{db::Upcast, diagnostics::Diagnostics, hir::db::Hir, Error};
 
@@ -13,7 +13,7 @@ use super::{transform::thir_transforms, Model};
 pub trait Thir: Hir + Upcast<dyn Hir> {
 	/// Lower a model to THIR
 	#[salsa::invoke(super::lower::lower_model)]
-	fn model_thir(&self) -> Arc<Model>;
+	fn model_thir(&self) -> Arc<Intermediate<Model>>;
 
 	/// Get the THIR after all THIR rewritings have been done
 	fn final_thir(&self) -> Arc<Model>;
@@ -23,7 +23,53 @@ pub trait Thir: Hir + Upcast<dyn Hir> {
 	fn sanity_check_thir(&self) -> Arc<Diagnostics<Error>>;
 }
 
+/// Represents an intermediate query result which can be taken
+/// at some point, making any future reads panic.
+///
+/// This is used to avoid cloning the model when we know we can actually
+/// discard the previous value because it won't be used anymore.
+#[derive(Debug)]
+pub struct Intermediate<T>(RwLock<Option<T>>);
+
+impl<T> Intermediate<T> {
+	/// Create a new intermediate value
+	pub fn new(value: T) -> Self {
+		Self(RwLock::new(Some(value)))
+	}
+
+	/// Take the value of this intermediate, making any future reads fail
+	pub fn take(&self) -> T {
+		self.0
+			.write()
+			.unwrap()
+			.take()
+			.expect("Intermediate already taken")
+	}
+
+	/// Read this intermediate value without taking it
+	pub fn get(&self) -> IntermediateValue<T> {
+		IntermediateValue(self.0.read().unwrap())
+	}
+}
+
+/// Access an intermediate value
+pub struct IntermediateValue<'a, T>(RwLockReadGuard<'a, Option<T>>);
+
+impl<'a, T> AsRef<T> for IntermediateValue<'a, T> {
+	fn as_ref(&self) -> &T {
+		self.0.as_ref().expect("Intermediate already taken")
+	}
+}
+
+impl<T: PartialEq> PartialEq for Intermediate<T> {
+	fn eq(&self, other: &Self) -> bool {
+		self.0.read().unwrap().as_ref() == other.0.read().unwrap().as_ref()
+	}
+}
+
+impl<T: Eq> Eq for Intermediate<T> {}
+
 fn final_thir(db: &dyn Thir) -> Arc<Model> {
 	let model = db.model_thir();
-	Arc::new(thir_transforms()(db, &model))
+	Arc::new(thir_transforms()(db, model.take()))
 }

--- a/crates/shackle/src/thir/ir/annotations.rs
+++ b/crates/shackle/src/thir/ir/annotations.rs
@@ -9,7 +9,7 @@ use super::{
 
 /// Collection of annotations
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct Annotations<T> {
+pub struct Annotations<T: Marker = ()> {
 	annotations: Vec<Expression<T>>,
 }
 

--- a/crates/shackle/src/thir/ir/domain.rs
+++ b/crates/shackle/src/thir/ir/domain.rs
@@ -13,7 +13,7 @@ pub use crate::hir::{OptType, VarType};
 
 /// Ascribed domain of a variable
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct Domain<T = ()> {
+pub struct Domain<T: Marker = ()> {
 	ty: Ty,
 	data: DomainData<T>,
 	origin: Origin,
@@ -218,7 +218,7 @@ impl<T: Marker> Domain<T> {
 
 /// Ascribed domain of a variable
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub enum DomainData<T = ()> {
+pub enum DomainData<T: Marker = ()> {
 	/// Bounded by an expression
 	Bounded(Box<Expression<T>>),
 	/// Array index sets and element domain

--- a/crates/shackle/src/thir/ir/item.rs
+++ b/crates/shackle/src/thir/ir/item.rs
@@ -56,7 +56,7 @@ impl<T> Item<T> {
 
 /// Annotation item
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Annotation<T = ()> {
+pub struct Annotation<T: Marker = ()> {
 	constructor: Constructor<T>,
 }
 
@@ -100,7 +100,7 @@ impl<T: Marker> Annotation<T> {
 
 /// Constraint item
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Constraint<T = ()> {
+pub struct Constraint<T: Marker = ()> {
 	expression: Expression<T>,
 	annotations: Annotations<T>,
 	top_level: bool,
@@ -152,7 +152,7 @@ pub type ConstraintId<T = ()> = ArenaIndex<ConstraintItem<T>>;
 
 /// A declaration item
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Declaration<T = ()> {
+pub struct Declaration<T: Marker = ()> {
 	domain: Domain<T>,
 	name: Option<Identifier>,
 	definition: Option<Expression<T>>,
@@ -281,7 +281,7 @@ pub type EnumerationId<T = ()> = ArenaIndex<EnumerationItem<T>>;
 
 /// A enum item
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct Enumeration<T = ()> {
+pub struct Enumeration<T: Marker = ()> {
 	enum_type: EnumRef,
 	definition: Option<Vec<Constructor<T>>>,
 	annotations: Annotations<T>,
@@ -347,7 +347,7 @@ impl<T: Marker> Enumeration<T> {
 
 /// A constructor (either atomic or a constructor function)
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct Constructor<T = ()> {
+pub struct Constructor<T: Marker = ()> {
 	/// The name of this constructor
 	pub name: Option<Identifier>,
 	/// The constructor function parameters, or `None` if this is atomic
@@ -432,7 +432,7 @@ impl PartialEq<Identifier> for FunctionName {
 
 /// Function item
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Function<T = ()> {
+pub struct Function<T: Marker = ()> {
 	domain: Domain<T>,
 	name: FunctionName,
 	type_inst_vars: Vec<TyVar>,
@@ -646,7 +646,7 @@ impl<T: Marker> Function<T> {
 
 /// Output item
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Output<T = ()> {
+pub struct Output<T: Marker = ()> {
 	section: Option<Expression<T>>,
 	expression: Expression<T>,
 }
@@ -699,7 +699,7 @@ impl<T: Marker> Output<T> {
 
 /// Solve item
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Solve<T = ()> {
+pub struct Solve<T: Marker = ()> {
 	/// Solve goal
 	goal: Goal<T>,
 	/// Annotations
@@ -775,7 +775,7 @@ impl<T: Marker> Solve<T> {
 
 /// Solve method and objective
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Goal<T = ()> {
+pub enum Goal<T: Marker = ()> {
 	/// Satisfaction problem
 	Satisfy,
 	/// Maximize the given objective
@@ -792,7 +792,7 @@ pub enum Goal<T = ()> {
 
 /// ID of an item
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum ItemId<T = ()> {
+pub enum ItemId<T: Marker = ()> {
 	/// Annotation item
 	Annotation(AnnotationId<T>),
 	/// Constraint item
@@ -809,9 +809,9 @@ pub enum ItemId<T = ()> {
 	Solve,
 }
 
-impl_enum_from!(ItemId<T>::Annotation(AnnotationId<T>));
-impl_enum_from!(ItemId<T>::Constraint(ConstraintId<T>));
-impl_enum_from!(ItemId<T>::Declaration(DeclarationId<T>));
-impl_enum_from!(ItemId<T>::Enumeration(EnumerationId<T>));
-impl_enum_from!(ItemId<T>::Function(FunctionId<T>));
-impl_enum_from!(ItemId<T>::Output(OutputId<T>));
+impl_enum_from!(ItemId<T: Marker>::Annotation(AnnotationId<T>));
+impl_enum_from!(ItemId<T: Marker>::Constraint(ConstraintId<T>));
+impl_enum_from!(ItemId<T: Marker>::Declaration(DeclarationId<T>));
+impl_enum_from!(ItemId<T: Marker>::Enumeration(EnumerationId<T>));
+impl_enum_from!(ItemId<T: Marker>::Function(FunctionId<T>));
+impl_enum_from!(ItemId<T: Marker>::Output(OutputId<T>));

--- a/crates/shackle/src/thir/ir/mod.rs
+++ b/crates/shackle/src/thir/ir/mod.rs
@@ -27,7 +27,7 @@ use super::db::Thir;
 
 /// A model
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct Model<T = ()> {
+pub struct Model<T: Marker = ()> {
 	annotations: Arena<AnnotationItem<T>>,
 	constraints: Arena<ConstraintItem<T>>,
 	declarations: Arena<DeclarationItem<T>>,
@@ -371,12 +371,12 @@ impl<T: Marker> Model<T> {
 	}
 }
 
-impl_index!(Model<T>[self, index: AnnotationId<T>] -> AnnotationItem<T> { self.annotations[index] });
-impl_index!(Model<T>[self, index: ConstraintId<T>] -> ConstraintItem<T> { self.constraints[index] });
-impl_index!(Model<T>[self, index: DeclarationId<T>] -> DeclarationItem<T> { self.declarations[index] });
-impl_index!(Model<T>[self, index: EnumerationId<T>] -> EnumerationItem<T> { self.enumerations[index] });
-impl_index!(Model<T>[self, index: FunctionId<T>] -> FunctionItem<T> { self.functions[index] });
-impl_index!(Model<T>[self, index: OutputId<T>] -> OutputItem<T> { self.outputs[index] });
+impl_index!(Model<T: Marker>[self, index: AnnotationId<T>] -> AnnotationItem<T> { self.annotations[index] });
+impl_index!(Model<T: Marker>[self, index: ConstraintId<T>] -> ConstraintItem<T> { self.constraints[index] });
+impl_index!(Model<T: Marker>[self, index: DeclarationId<T>] -> DeclarationItem<T> { self.declarations[index] });
+impl_index!(Model<T: Marker>[self, index: EnumerationId<T>] -> EnumerationItem<T> { self.enumerations[index] });
+impl_index!(Model<T: Marker>[self, index: FunctionId<T>] -> FunctionItem<T> { self.functions[index] });
+impl_index!(Model<T: Marker>[self, index: OutputId<T>] -> OutputItem<T> { self.outputs[index] });
 
 impl<T: Marker> Index<EnumMemberId<T>> for Model<T> {
 	type Output = Constructor<T>;
@@ -389,7 +389,7 @@ impl<T: Marker> Index<EnumMemberId<T>> for Model<T> {
 
 /// Result of looking up a function by its signature
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct FunctionLookup<T> {
+pub struct FunctionLookup<T: Marker> {
 	/// Id of the resolved function
 	pub function: FunctionId<T>,
 	/// The function entry (i.e. not instantiated with the call arguments)

--- a/crates/shackle/src/thir/ir/traverse/fold.rs
+++ b/crates/shackle/src/thir/ir/traverse/fold.rs
@@ -550,13 +550,16 @@ pub trait Folder<'a, Dst: Marker, Src: Marker = ()> {
 	}
 
 	/// Fold a domain
+	///
+	/// When overriding this, it is generally a good idea to wrap the body in `utils::maybe_grow_stack`
+	/// to prevent stack overflows on highly nested types
 	fn fold_domain(
 		&mut self,
 		db: &'a dyn Thir,
 		model: &'a Model<Src>,
 		domain: &'a Domain<Src>,
 	) -> Domain<Dst> {
-		fold_domain(self, db, model, domain)
+		maybe_grow_stack(|| fold_domain(self, db, model, domain))
 	}
 
 	/// Fold a case pattern

--- a/crates/shackle/src/thir/ir/traverse/visit.rs
+++ b/crates/shackle/src/thir/ir/traverse/visit.rs
@@ -1,4 +1,4 @@
-use crate::thir::*;
+use crate::{thir::*, utils::maybe_grow_stack};
 
 /// Trait for visiting THIR nodes
 ///
@@ -53,8 +53,13 @@ pub trait Visitor<'a, T: Marker = ()> {
 	}
 
 	/// Visit an expression
+	///
+	/// When overriding this, it is generally a good idea to wrap the body in `utils::maybe_grow_stack`
+	/// to prevent stack overflows on highly nested models
 	fn visit_expression(&mut self, model: &'a Model<T>, expression: &'a Expression<T>) {
-		visit_expression(self, model, expression);
+		maybe_grow_stack(|| {
+			visit_expression(self, model, expression);
+		});
 	}
 
 	/// Visit an absent literal

--- a/crates/shackle/src/thir/lower.rs
+++ b/crates/shackle/src/thir/lower.rs
@@ -2263,19 +2263,18 @@ enum Destructuring {
 /// Lower a model to THIR
 pub fn lower_model(db: &dyn Thir) -> Arc<Intermediate<Model>> {
 	log::info!("Lowering model to THIR");
-	assert!(
-		db.all_errors().is_empty(),
-		"Errors present, cannot lower model.\n{}",
-		db.all_errors()
-			.iter()
-			.map(|e| format!("{:#?}", e))
-			.collect::<Vec<_>>()
-			.join("\n")
-	);
+	let items = db.run_hir_phase().unwrap_or_else(|e| {
+		panic!(
+			"Errors present, cannot lower model.\n{}",
+			e.iter()
+				.map(|e| format!("{:#?}", e))
+				.collect::<Vec<_>>()
+				.join("\n")
+		)
+	});
 	let ids = db.identifier_registry();
 	let counts = db.entity_counts();
 	let mut collector = ItemCollector::new(db, &ids, &counts);
-	let items = db.lookup_topological_sorted_items();
 	for item in items.iter() {
 		collector.collect_item(*item);
 	}

--- a/crates/shackle/src/thir/pretty_print.rs
+++ b/crates/shackle/src/thir/pretty_print.rs
@@ -1,6 +1,8 @@
 //! Pretty printing of THIR as MiniZinc
 //!
 
+use crate::utils::maybe_grow_stack;
+
 use super::db::Thir;
 use super::{
 	AnnotationId, Callable, ConstraintId, DeclarationId, Domain, DomainData, EnumerationId,
@@ -12,7 +14,7 @@ use std::fmt::Write;
 static MINIZINC_COMPAT: &str = include_str!("../../../../share/minizinc/compat.mzn");
 
 /// Pretty prints THIR as MiniZinc
-pub struct PrettyPrinter<'a, T = ()> {
+pub struct PrettyPrinter<'a, T: Marker = ()> {
 	db: &'a dyn Thir,
 	model: &'a Model<T>,
 	/// Whether to output a model compatible with old MiniZinc (default `true`)
@@ -419,6 +421,10 @@ impl<'a, T: Marker> PrettyPrinter<'a, T> {
 
 	/// Pretty print an expression
 	pub fn pretty_print_expression(&self, expression: &Expression<T>) -> String {
+		maybe_grow_stack(|| self.pretty_print_expression_inner(expression))
+	}
+
+	fn pretty_print_expression_inner(&self, expression: &Expression<T>) -> String {
 		let mut out = match &**expression {
 			ExpressionData::Absent => "<>".to_owned(),
 			ExpressionData::ArrayAccess(aa) => format!(

--- a/crates/shackle/src/thir/pretty_print.rs
+++ b/crates/shackle/src/thir/pretty_print.rs
@@ -322,6 +322,10 @@ impl<'a, T: Marker> PrettyPrinter<'a, T> {
 
 	/// Pretty print a domain
 	pub fn pretty_print_domain(&self, domain: &Domain<T>) -> String {
+		maybe_grow_stack(|| self.pretty_print_domain_inner(domain))
+	}
+
+	fn pretty_print_domain_inner(&self, domain: &Domain<T>) -> String {
 		let ty = domain.ty();
 		match &**domain {
 			DomainData::Array(dim, el) => {

--- a/crates/shackle/src/thir/sanity_check.rs
+++ b/crates/shackle/src/thir/sanity_check.rs
@@ -18,10 +18,11 @@ use super::{db::Thir, pretty_print::PrettyPrinter};
 /// This should give no errors (as for the THIR to exist, it must have come
 /// from a valid source program).
 pub fn sanity_check_thir(db: &dyn Thir) -> Arc<Diagnostics<Error>> {
-	let model = db.model_thir();
+	let initial_thir = db.model_thir();
+	let model = initial_thir.get();
 
 	// Pretty print with extra info for sanity checking types
-	let mut printer = PrettyPrinter::new(db, &model);
+	let mut printer = PrettyPrinter::new(db, model.as_ref());
 	printer.old_compat = false;
 	printer.debug_types = true;
 	let code = printer.pretty_print();

--- a/crates/shackle/src/thir/transform/call_by_name.rs
+++ b/crates/shackle/src/thir/transform/call_by_name.rs
@@ -135,7 +135,7 @@ pub fn inline_call_by_name(db: &dyn Thir, model: Model) -> Model {
 	log::info!("Inlining call by name functions");
 	let mut inliner = Inliner {
 		replacement_map: ReplacementMap::default(),
-		model: Model::default(),
+		model: Model::with_capacities(&model.entity_counts()),
 		ids: db.identifier_registry(),
 		map: FxHashMap::default(),
 	};

--- a/crates/shackle/src/thir/transform/call_by_name.rs
+++ b/crates/shackle/src/thir/transform/call_by_name.rs
@@ -18,6 +18,7 @@ use crate::{
 		Model, ResolvedIdentifier,
 	},
 	utils::maybe_grow_stack,
+	Result,
 };
 
 struct Inliner<Dst: Marker, Src: Marker = ()> {
@@ -131,7 +132,7 @@ impl<Dst: Marker, Src: Marker> Folder<'_, Dst, Src> for Inliner<Dst, Src> {
 
 /// Perform inlining to implement call-by-name semantics for functions annotated with
 /// `:: mzn_inline_call_by_name`.
-pub fn inline_call_by_name(db: &dyn Thir, model: Model) -> Model {
+pub fn inline_call_by_name(db: &dyn Thir, model: Model) -> Result<Model> {
 	log::info!("Inlining call by name functions");
 	let mut inliner = Inliner {
 		replacement_map: ReplacementMap::default(),
@@ -140,7 +141,7 @@ pub fn inline_call_by_name(db: &dyn Thir, model: Model) -> Model {
 		map: FxHashMap::default(),
 	};
 	inliner.add_model(db, &model);
-	inliner.model
+	Ok(inliner.model)
 }
 
 #[cfg(test)]

--- a/crates/shackle/src/thir/transform/capturing_fn.rs
+++ b/crates/shackle/src/thir/transform/capturing_fn.rs
@@ -20,6 +20,7 @@ use crate::{
 		IntegerLiteral, Item, Marker, Model, ResolvedIdentifier, TupleAccess, TupleLiteral,
 	},
 	utils::maybe_grow_stack,
+	Result,
 };
 
 /// Computes all globals this function (transitively) refers to
@@ -336,7 +337,7 @@ impl<Dst: Marker> Decapturer<Dst> {
 }
 
 /// Rewrite capturing functions into non-capturing functions
-pub fn decapture_model(db: &dyn Thir, model: Model) -> Model {
+pub fn decapture_model(db: &dyn Thir, model: Model) -> Result<Model> {
 	log::info!("Rewriting functions to be non-capturing");
 	let mut d = Decapturer {
 		model: Model::with_capacities(&model.entity_counts()),
@@ -347,7 +348,7 @@ pub fn decapture_model(db: &dyn Thir, model: Model) -> Model {
 		current: None,
 	};
 	d.add_model(db, &model);
-	d.model
+	Ok(d.model)
 }
 
 #[cfg(test)]

--- a/crates/shackle/src/thir/transform/capturing_fn.rs
+++ b/crates/shackle/src/thir/transform/capturing_fn.rs
@@ -339,7 +339,7 @@ impl<Dst: Marker> Decapturer<Dst> {
 pub fn decapture_model(db: &dyn Thir, model: Model) -> Model {
 	log::info!("Rewriting functions to be non-capturing");
 	let mut d = Decapturer {
-		model: Model::default(),
+		model: Model::with_capacities(&model.entity_counts()),
 		replacement_map: ReplacementMap::default(),
 		captures: Captures::get(&model),
 		decaptured: FxHashMap::default(),

--- a/crates/shackle/src/thir/transform/case.rs
+++ b/crates/shackle/src/thir/transform/case.rs
@@ -1,1 +1,0 @@
-//! Rewrite case expressions into if-then-else

--- a/crates/shackle/src/thir/transform/comprehension.rs
+++ b/crates/shackle/src/thir/transform/comprehension.rs
@@ -19,6 +19,7 @@ use crate::{
 		Model, ResolvedIdentifier, SetComprehension, VarType,
 	},
 	utils::maybe_grow_stack,
+	Result,
 };
 
 use super::top_down_type::add_coercion;
@@ -437,7 +438,7 @@ impl<'a, T: Marker> ScopeTester<'a, T> {
 }
 
 /// Desugar comprehensions
-pub fn desugar_comprehension(db: &dyn Thir, model: Model) -> Model {
+pub fn desugar_comprehension(db: &dyn Thir, model: Model) -> Result<Model> {
 	log::info!("Desugaring comprehensions");
 	let mut r = ComprehensionRewriter {
 		ids: db.identifier_registry(),
@@ -445,7 +446,7 @@ pub fn desugar_comprehension(db: &dyn Thir, model: Model) -> Model {
 		result: Model::default(),
 	};
 	r.add_model(db, &model);
-	r.result
+	Ok(r.result)
 }
 
 #[cfg(test)]

--- a/crates/shackle/src/thir/transform/domain_constraint.rs
+++ b/crates/shackle/src/thir/transform/domain_constraint.rs
@@ -887,7 +887,7 @@ pub fn rewrite_domains(db: &dyn Thir, model: Model) -> Model {
 	log::info!("Rewriting domains into constraints and unpacking structured variables");
 	let mut d = DomainRewriter {
 		ids: db.identifier_registry(),
-		model: Model::default(),
+		model: Model::with_capacities(&model.entity_counts()),
 		replacement_map: ReplacementMap::default(),
 		domain_constraints: FxHashMap::default(),
 		return_constraints: FxHashMap::default(),

--- a/crates/shackle/src/thir/transform/domain_constraint.rs
+++ b/crates/shackle/src/thir/transform/domain_constraint.rs
@@ -26,6 +26,7 @@ use crate::{
 		Domain, DomainData, Expression, FunctionId, Generator, Item, Let, LetItem, LookupCall,
 		Marker, Model, RecordAccess, RecordLiteral, TupleAccess, TupleLiteral,
 	},
+	Result,
 };
 
 enum DomainConstraint<T: Marker> {
@@ -883,7 +884,7 @@ impl<Dst: Marker, Src: Marker> DomainRewriter<Dst, Src> {
 }
 
 /// Rewrite domains
-pub fn rewrite_domains(db: &dyn Thir, model: Model) -> Model {
+pub fn rewrite_domains(db: &dyn Thir, model: Model) -> Result<Model> {
 	log::info!("Rewriting domains into constraints and unpacking structured variables");
 	let mut d = DomainRewriter {
 		ids: db.identifier_registry(),
@@ -893,7 +894,7 @@ pub fn rewrite_domains(db: &dyn Thir, model: Model) -> Model {
 		return_constraints: FxHashMap::default(),
 	};
 	d.add_model(db, &model);
-	d.model
+	Ok(d.model)
 }
 
 #[cfg(test)]

--- a/crates/shackle/src/thir/transform/domain_constraint.rs
+++ b/crates/shackle/src/thir/transform/domain_constraint.rs
@@ -28,7 +28,7 @@ use crate::{
 	},
 };
 
-enum DomainConstraint<T> {
+enum DomainConstraint<T: Marker> {
 	Array(
 		Origin,
 		Option<IndexSet<T>>,
@@ -39,12 +39,12 @@ enum DomainConstraint<T> {
 	Bound(DeclarationId<T>),
 }
 
-enum IndexSet<T> {
+enum IndexSet<T: Marker> {
 	OneDimensional(DeclarationId<T>),
 	MutliDimensional(Vec<(IntegerLiteral, DeclarationId<T>)>),
 }
 
-struct DomainRewriter<Dst, Src = ()> {
+struct DomainRewriter<Dst: Marker, Src: Marker = ()> {
 	replacement_map: ReplacementMap<Dst, Src>,
 	model: Model<Dst>,
 	ids: Arc<IdentifierRegistry>,
@@ -883,7 +883,8 @@ impl<Dst: Marker, Src: Marker> DomainRewriter<Dst, Src> {
 }
 
 /// Rewrite domains
-pub fn rewrite_domains(db: &dyn Thir, model: &Model) -> Model {
+pub fn rewrite_domains(db: &dyn Thir, model: Model) -> Model {
+	log::info!("Rewriting domains into constraints and unpacking structured variables");
 	let mut d = DomainRewriter {
 		ids: db.identifier_registry(),
 		model: Model::default(),
@@ -891,7 +892,7 @@ pub fn rewrite_domains(db: &dyn Thir, model: &Model) -> Model {
 		domain_constraints: FxHashMap::default(),
 		return_constraints: FxHashMap::default(),
 	};
-	d.add_model(db, model);
+	d.add_model(db, &model);
 	d.model
 }
 

--- a/crates/shackle/src/thir/transform/erase_enum.rs
+++ b/crates/shackle/src/thir/transform/erase_enum.rs
@@ -399,12 +399,12 @@ impl<Src: Marker, Dst: Marker> EnumEraser<Dst, Src> {
 pub fn erase_enum(db: &dyn Thir, model: Model) -> Model {
 	log::info!("Erasing enums into ints");
 	let mut c = EnumEraser {
-		model: Model::default(),
+		model: Model::with_capacities(&model.entity_counts()),
 		replacement_map: ReplacementMap::default(),
 		ids: db.identifier_registry(),
 		tys: db.type_registry(),
 		enum_definitions: Vec::with_capacity(model.enumerations_len() as usize),
-		mzn_enum_for_item: ArenaMap::with_capacity(model.enumerations_len() as usize),
+		mzn_enum_for_item: ArenaMap::with_capacity(model.enumerations_len()),
 		enum_id_for_ty: FxHashMap::default(),
 		identifier_replacement: FxHashMap::default(),
 	};

--- a/crates/shackle/src/thir/transform/erase_opt.rs
+++ b/crates/shackle/src/thir/transform/erase_opt.rs
@@ -426,7 +426,7 @@ impl<Src: Marker, Dst: Marker> OptEraser<Dst, Src> {
 pub fn erase_opt(db: &dyn Thir, model: Model) -> Model {
 	log::info!("Erasing option types");
 	let mut c = OptEraser {
-		model: Model::default(),
+		model: Model::with_capacities(&model.entity_counts()),
 		replacement_map: ReplacementMap::default(),
 		ids: db.identifier_registry(),
 		tys: db.type_registry(),

--- a/crates/shackle/src/thir/transform/erase_record.rs
+++ b/crates/shackle/src/thir/transform/erase_record.rs
@@ -103,7 +103,7 @@ impl<Dst: Marker, Src: Marker> Folder<'_, Dst, Src> for RecordEraser<Dst, Src> {
 pub fn erase_record(db: &dyn Thir, model: Model) -> Model {
 	log::info!("Erasing record types");
 	let mut c = RecordEraser {
-		model: Model::default(),
+		model: Model::with_capacities(&model.entity_counts()),
 		replacement_map: ReplacementMap::default(),
 	};
 	c.add_model(db, &model);

--- a/crates/shackle/src/thir/transform/function_dispatch.rs
+++ b/crates/shackle/src/thir/transform/function_dispatch.rs
@@ -17,6 +17,7 @@ use crate::{
 		RecordAccess, SetComprehension, TupleAccess, TupleLiteral,
 	},
 	ty::{Ty, TyData},
+	Result,
 };
 
 use super::top_down_type::add_coercion;
@@ -552,7 +553,7 @@ fn dispatches_to(db: &dyn Thir, a: Ty, b: Ty) -> bool {
 }
 
 /// Add function dispatch headers
-pub fn function_dispatch(db: &dyn Thir, model: Model) -> Model {
+pub fn function_dispatch(db: &dyn Thir, model: Model) -> Result<Model> {
 	log::info!("Generating function dispatch preambles");
 
 	let mut overloaded: FxHashMap<_, Vec<FunctionId>> = FxHashMap::default();
@@ -609,7 +610,7 @@ pub fn function_dispatch(db: &dyn Thir, model: Model) -> Model {
 		overloaded: FxHashMap::default(),
 	};
 	c.add_model(db, &model);
-	c.model
+	Ok(c.model)
 }
 
 #[cfg(test)]

--- a/crates/shackle/src/thir/transform/function_dispatch.rs
+++ b/crates/shackle/src/thir/transform/function_dispatch.rs
@@ -602,7 +602,7 @@ pub fn function_dispatch(db: &dyn Thir, model: Model) -> Model {
 	}
 
 	let mut c = DispatchRewriter {
-		model: Model::default(),
+		model: Model::with_capacities(&model.entity_counts()),
 		replacement_map: ReplacementMap::default(),
 		ids: db.identifier_registry(),
 		dispatch_to,

--- a/crates/shackle/src/thir/transform/function_dispatch.rs
+++ b/crates/shackle/src/thir/transform/function_dispatch.rs
@@ -21,7 +21,7 @@ use crate::{
 
 use super::top_down_type::add_coercion;
 
-struct DispatchRewriter<Dst, Src = ()> {
+struct DispatchRewriter<Dst: Marker, Src: Marker = ()> {
 	model: Model<Dst>,
 	replacement_map: ReplacementMap<Dst, Src>,
 	ids: Arc<IdentifierRegistry>,
@@ -552,7 +552,9 @@ fn dispatches_to(db: &dyn Thir, a: Ty, b: Ty) -> bool {
 }
 
 /// Add function dispatch headers
-pub fn function_dispatch(db: &dyn Thir, model: &Model) -> Model {
+pub fn function_dispatch(db: &dyn Thir, model: Model) -> Model {
+	log::info!("Generating function dispatch preambles");
+
 	let mut overloaded: FxHashMap<_, Vec<FunctionId>> = FxHashMap::default();
 	for (idx, function) in model.top_level_functions() {
 		if function.body().is_some() {
@@ -606,7 +608,7 @@ pub fn function_dispatch(db: &dyn Thir, model: &Model) -> Model {
 		dispatch_to,
 		overloaded: FxHashMap::default(),
 	};
-	c.add_model(db, model);
+	c.add_model(db, &model);
 	c.model
 }
 

--- a/crates/shackle/src/thir/transform/name_mangle.rs
+++ b/crates/shackle/src/thir/transform/name_mangle.rs
@@ -8,10 +8,13 @@
 
 use rustc_hash::FxHashMap;
 
-use crate::thir::{db::Thir, FunctionId, FunctionName, Model};
+use crate::{
+	thir::{db::Thir, FunctionId, FunctionName, Model},
+	Result,
+};
 
 /// Mangle names of overloaded/specialised functions
-pub fn mangle_names(_db: &dyn Thir, mut model: Model) -> Model {
+pub fn mangle_names(_db: &dyn Thir, mut model: Model) -> Result<Model> {
 	log::info!("Mangling overloaded function names");
 
 	let mut overloaded: FxHashMap<_, Vec<FunctionId>> = FxHashMap::default();
@@ -32,7 +35,7 @@ pub fn mangle_names(_db: &dyn Thir, mut model: Model) -> Model {
 			}
 		}
 	}
-	model
+	Ok(model)
 }
 
 #[cfg(test)]

--- a/crates/shackle/src/thir/transform/name_mangle.rs
+++ b/crates/shackle/src/thir/transform/name_mangle.rs
@@ -11,8 +11,9 @@ use rustc_hash::FxHashMap;
 use crate::thir::{db::Thir, FunctionId, FunctionName, Model};
 
 /// Mangle names of overloaded/specialised functions
-pub fn mangle_names(_db: &dyn Thir, model: &Model) -> Model {
-	let mut model = model.clone();
+pub fn mangle_names(_db: &dyn Thir, mut model: Model) -> Model {
+	log::info!("Mangling overloaded function names");
+
 	let mut overloaded: FxHashMap<_, Vec<FunctionId>> = FxHashMap::default();
 	for (idx, function) in model.top_level_functions() {
 		if let FunctionName::Named(ident) = function.name() {

--- a/crates/shackle/src/thir/transform/output.rs
+++ b/crates/shackle/src/thir/transform/output.rs
@@ -13,19 +13,20 @@ use crate::{
 };
 
 /// Generate the output
-pub fn generate_output(db: &dyn Thir, model: &Model) -> Model {
+pub fn generate_output(db: &dyn Thir, mut model: Model) -> Model {
+	log::info!("Generating output");
+
 	let ids = db.identifier_registry();
 	let tys = db.type_registry();
 	let origin = Origin::Introduced("<generated-output>");
-	let mut model = model.clone();
 	let mut sections: FxHashMap<StringLiteral, Vec<Expression>> = FxHashMap::default();
 	let outputs = model.take_outputs();
 	for output in outputs {
 		let (_, output) = output.into_inner();
 		let (section, expression) = output.into_inner();
 		if let Some(s) = section {
-			let section = match s.into_inner().1 {
-				ExpressionData::StringLiteral(sl) => sl,
+			let section = match &*s {
+				ExpressionData::StringLiteral(sl) => sl.clone(),
 				_ => unreachable!(),
 			};
 			sections.entry(section).or_default().push(expression)

--- a/crates/shackle/src/thir/transform/output.rs
+++ b/crates/shackle/src/thir/transform/output.rs
@@ -10,10 +10,11 @@ use crate::{
 		db::Thir, source::Origin, Declaration, Domain, Expression, ExpressionData, Item,
 		LookupCall, LookupIdentifier, Model,
 	},
+	Result,
 };
 
 /// Generate the output
-pub fn generate_output(db: &dyn Thir, mut model: Model) -> Model {
+pub fn generate_output(db: &dyn Thir, mut model: Model) -> Result<Model> {
 	log::info!("Generating output");
 
 	let ids = db.identifier_registry();
@@ -107,7 +108,7 @@ pub fn generate_output(db: &dyn Thir, mut model: Model) -> Model {
 		model[idx].annotations_mut().push(output_ann);
 	}
 
-	model
+	Ok(model)
 }
 
 #[cfg(test)]

--- a/crates/shackle/src/thir/transform/top_down_type.rs
+++ b/crates/shackle/src/thir/transform/top_down_type.rs
@@ -14,6 +14,7 @@ use crate::{
 	},
 	ty::{FunctionType, PolymorphicFunctionType, Ty, TyData},
 	utils::maybe_grow_stack,
+	Result,
 };
 
 /// Create a let wrapping an expression into a declaration.
@@ -314,11 +315,11 @@ impl<'a, Src: Marker, Dst: Marker> TopDownTyper<'a, Dst, Src> {
 }
 
 /// Compute real types for bottom types
-pub fn top_down_type(db: &dyn Thir, model: Model) -> Model {
+pub fn top_down_type(db: &dyn Thir, model: Model) -> Result<Model> {
 	log::info!("Computing top-down types");
 	let mut tdt = TopDownTyper::default();
 	tdt.add_model(db, &model);
-	tdt.result
+	Ok(tdt.result)
 }
 
 #[cfg(test)]

--- a/crates/shackle/src/thir/transform/type_specialise.rs
+++ b/crates/shackle/src/thir/transform/type_specialise.rs
@@ -26,13 +26,13 @@ use crate::{
 	utils::DebugPrint,
 };
 
-struct SpecialisedFunction<Dst> {
+struct SpecialisedFunction<Dst: Marker> {
 	original: FunctionId,
 	ty_vars: TyParamInstantiations,
 	parameters: FxHashMap<DeclarationId, DeclarationId<Dst>>,
 }
 
-struct TypeSpecialiser<Dst> {
+struct TypeSpecialiser<Dst: Marker> {
 	specialised_model: Model<Dst>,
 	replacement_map: ReplacementMap<Dst>,
 	concrete: FxHashMap<(FunctionId, FunctionType), FunctionId<Dst>>,
@@ -531,7 +531,8 @@ impl<Dst: Marker> TypeSpecialiser<Dst> {
 }
 
 /// Type specialise a model
-pub fn type_specialise(db: &dyn Thir, model: &Model) -> Model {
+pub fn type_specialise(db: &dyn Thir, model: Model) -> Model {
+	log::info!("Performing type specialisation");
 	let ids = db.identifier_registry();
 	let mut ts = TypeSpecialiser {
 		replacement_map: ReplacementMap::default(),
@@ -542,7 +543,7 @@ pub fn type_specialise(db: &dyn Thir, model: &Model) -> Model {
 		ids,
 		position: FxHashMap::default(),
 	};
-	ts.add_model(db, model);
+	ts.add_model(db, &model);
 	ts.specialised_model
 }
 

--- a/crates/shackle/src/thir/transform/type_specialise.rs
+++ b/crates/shackle/src/thir/transform/type_specialise.rs
@@ -40,6 +40,7 @@ struct TypeSpecialiser<Dst: Marker> {
 	todo: Vec<SpecialisedFunction<Dst>>,
 	ids: Arc<IdentifierRegistry>,
 	position: FxHashMap<FunctionId, ItemId<Dst>>,
+	count: usize,
 }
 
 impl<Dst: Marker> Folder<'_, Dst> for TypeSpecialiser<Dst> {
@@ -303,6 +304,7 @@ impl<Dst: Marker> TypeSpecialiser<Dst> {
 			"Created {}",
 			PrettyPrinter::new(db, &self.specialised_model).pretty_print_signature(idx.into())
 		);
+		self.count += 1;
 		idx
 	}
 
@@ -536,14 +538,16 @@ pub fn type_specialise(db: &dyn Thir, model: Model) -> Model {
 	let ids = db.identifier_registry();
 	let mut ts = TypeSpecialiser {
 		replacement_map: ReplacementMap::default(),
-		specialised_model: Model::default(),
+		specialised_model: Model::with_capacities(&model.entity_counts()),
 		concrete: FxHashMap::default(),
 		specialised: Vec::new(),
 		todo: Vec::new(),
 		ids,
 		position: FxHashMap::default(),
+		count: 0,
 	};
 	ts.add_model(db, &model);
+	log::info!("Created {} specialised functions", ts.count);
 	ts.specialised_model
 }
 

--- a/crates/shackle/src/ty/functions.rs
+++ b/crates/shackle/src/ty/functions.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashMap;
 
 use crate::{
 	db::{InternedString, Interner},
-	utils::DebugPrint,
+	utils::{maybe_grow_stack, DebugPrint},
 };
 
 use super::{OptType, Ty, TyData, TyVarRef, VarType};
@@ -698,6 +698,15 @@ impl PolymorphicFunctionType {
 
 	/// Collects the types to instantiate unbound type-inst variables with.
 	pub fn collect_instantiations(
+		db: &dyn Interner,
+		add_instantiation: &mut impl FnMut(TyVarRef, Ty) -> bool,
+		arg: Ty,
+		param: Ty,
+	) -> bool {
+		maybe_grow_stack(|| Self::collect_instantiations_inner(db, add_instantiation, arg, param))
+	}
+
+	fn collect_instantiations_inner(
 		db: &dyn Interner,
 		add_instantiation: &mut impl FnMut(TyVarRef, Ty) -> bool,
 		arg: Ty,

--- a/docs/src/microzinc.md
+++ b/docs/src/microzinc.md
@@ -23,65 +23,67 @@ variables introduced in the same let expression.
 
 MicroZinc is defined using the following syntax,
 
-\\[
+<div>
+\[
 \begin{array}{lcl}
 \mathit{program} &::=&
-\mathit{func}\* \\\\
+\mathit{func}* \\
 \mathit{func} &::=&
-\mathsf{function}~\mathit{typeinst}~\mathsf{:}~\mathit{ident}~\mathsf{(}\mathit{typing} [\mathsf{,}~ \mathit{typing}]\*\mathsf{)}~[\mathsf{=}~\mathit{letExpr}]\mathsf{;}\\\\&|&
-\mathsf{predicate}~\mathit{ident}~\mathsf{(}\mathit{typing} [\mathsf{,}~ \mathit{typing}]\*\mathsf{)}~[\mathsf{=}~\mathit{letRoot}]\mathsf{;} \\\\
+\mathsf{function}~\mathit{typeinst}~\mathsf{:}~\mathit{ident}~\mathsf{(}\mathit{typing} [\mathsf{,}~ \mathit{typing}]*\mathsf{)}~[\mathsf{=}~\mathit{letExpr}]\mathsf{;}\\&|&
+\mathsf{predicate}~\mathit{ident}~\mathsf{(}\mathit{typing} [\mathsf{,}~ \mathit{typing}]*\mathsf{)}~[\mathsf{=}~\mathit{letRoot}]\mathsf{;} \\
 \mathit{typing} &::=&
-\mathit{typeinst}~\mathsf{:}~\mathit{ident} \\\\
-\\\\
+\mathit{typeinst}~\mathsf{:}~\mathit{ident} \\
+\\
 \mathit{expr} &::=&
-\mathit{letExpr} \\\\&|&
-\mathit{ident}~\mathsf{(}\mathit{val} [ \mathsf{,}~ \mathit{val}]\*\mathsf{)} \\\\&|&
-\mathsf{if}~\mathit{val}~\mathsf{then}~\mathit{letExpr}~[\mathsf{elseif}~\mathit{val}~\mathsf{then}~\mathit{letExpr}]\*~\mathsf{else}~\mathit{letExpr}~\mathsf{endif} \\\\&|&
-\mathsf{[}[\mathit{tuple}\mathsf{:}]~\mathit{letExpr}~\mathsf{|}~\mathit{genExpr} [ \mathsf{,}~ \mathit{genExpr}]\*\mathsf{]} \\\\
+\mathit{letExpr} \\&|&
+\mathit{ident}~\mathsf{(}\mathit{val} [ \mathsf{,}~ \mathit{val}]*\mathsf{)} \\&|&
+\mathsf{if}~\mathit{val}~\mathsf{then}~\mathit{letExpr}~[\mathsf{elseif}~\mathit{val}~\mathsf{then}~\mathit{letExpr}]*~\mathsf{else}~\mathit{letExpr}~\mathsf{endif} \\&|&
+\mathsf{[}[\mathit{tuple}\mathsf{:}]~\mathit{letExpr}~\mathsf{|}~\mathit{genExpr} [ \mathsf{,}~ \mathit{genExpr}]*\mathsf{]} \\
 \mathit{rootExpr} &::=&
-\mathit{letRoot} \\\\&|&
-\mathit{ident}~\mathsf{(}\mathit{val} [ \mathsf{,}~ \mathit{val}]\*\mathsf{)} \\\\&|&
-\mathsf{if}~\mathit{val}~\mathsf{then}~\mathit{letRoot}~[\mathsf{elseif}~\mathit{val}~\mathsf{then}~\mathit{letRoot}]\*~\mathsf{else}~\mathit{letRoot}~\mathsf{endif} \\\\&|&
-\mathsf{forall\*root}\mathsf{(}\mathsf{[}\mathit{letRoot}~\mathsf{|}~\mathit{genExpr} [ \mathsf{,}~ \mathit{genExpr}]\*\mathsf{]}\mathsf{)} \\\\
+\mathit{letRoot} \\&|&
+\mathit{ident}~\mathsf{(}\mathit{val} [ \mathsf{,}~ \mathit{val}]*\mathsf{)} \\&|&
+\mathsf{if}~\mathit{val}~\mathsf{then}~\mathit{letRoot}~[\mathsf{elseif}~\mathit{val}~\mathsf{then}~\mathit{letRoot}]*~\mathsf{else}~\mathit{letRoot}~\mathsf{endif} \\&|&
+\mathsf{forall*root}\mathsf{(}\mathsf{[}\mathit{letRoot}~\mathsf{|}~\mathit{genExpr} [ \mathsf{,}~ \mathit{genExpr}]*\mathsf{]}\mathsf{)} \\
 \mathit{letExpr} &::=&
-\mathit{val} \\\\&|&
-\mathsf{let}~\mathsf{\\\{}\mathit{item}\*\mathsf{\\\}}~\mathsf{in}~\mathit{val} \\\\
+\mathit{val} \\&|&
+\mathsf{let}~\mathsf{\\{}\mathit{item}*\mathsf{\\}}~\mathsf{in}~\mathit{val} \\
 \mathit{letRoot} &::=&
-\mathsf{let}~\mathsf{\\\{}\mathit{item}\*\mathsf{\\\}}~\mathsf{in}~\mathsf{root} \\\\
+\mathsf{let}~\mathsf{\\{}\mathit{item}*\mathsf{\\}}~\mathsf{in}~\mathsf{root} \\
 \mathit{item} &::=&
-\mathit{typing}~\mathsf{;} \\\\&|&
-\mathit{typing}~\mathsf{=}~\mathit{expr}~\mathsf{;} \\\\&|&
-\mathsf{constraint}~\mathit{rootExpr}~\mathsf{;} \\\\
+\mathit{typing}~\mathsf{;} \\&|&
+\mathit{typing}~\mathsf{=}~\mathit{expr}~\mathsf{;} \\&|&
+\mathsf{constraint}~\mathit{rootExpr}~\mathsf{;} \\
 \mathit{genExpr} &::=&
-\mathit{ident}~\mathsf{in}~\mathit{letExpr}~[\mathsf{where}~\mathit{letExpr}] \\\\&|&
-\mathit{ident}~\mathsf{=}~\mathit{letExpr} \\\\
+\mathit{ident}~\mathsf{in}~\mathit{letExpr}~[\mathsf{where}~\mathit{letExpr}] \\&|&
+\mathit{ident}~\mathsf{=}~\mathit{letExpr} \\
 \mathit{val} &::=&
-\mathit{lit}~|~\mathit{range}~|~\mathit{tuple} \\\\&|&
-\mathsf{\\{}\mathit{lit}~\mathsf{,}~ [\mathit{lit}~\mathsf{,}]\*\mathsf{\\}} \\\\&|&
-\mathsf{array}\mathit{int}\mathsf{d(}\mathit{range}~\mathsf{,}~[\mathit{range}~\mathsf{,}]\*~\mathsf{[}\mathit{lit}~\mathsf{,}~ [\mathit{lit}~\mathsf{,}]\*\mathsf{])} \\\\&|&
-\mathit{ident}~\mathsf{.}~\mathit{int} \\\\&|&
-\mathit{ident}~\mathsf{[}\mathit{lit}\mathsf{]} \\\\
+\mathit{lit}~|~\mathit{range}~|~\mathit{tuple} \\&|&
+\mathsf{\{}\mathit{lit}~\mathsf{,}~ [\mathit{lit}~\mathsf{,}]*\mathsf{\}} \\&|&
+\mathsf{array}\mathit{int}\mathsf{d(}\mathit{range}~\mathsf{,}~[\mathit{range}~\mathsf{,}]*~\mathsf{[}\mathit{lit}~\mathsf{,}~ [\mathit{lit}~\mathsf{,}]*\mathsf{])} \\&|&
+\mathit{ident}~\mathsf{.}~\mathit{int} \\&|&
+\mathit{ident}~\mathsf{[}\mathit{lit}\mathsf{]} \\
 \mathit{tuple} &::=&
-\mathsf{(}\mathit{lit}~\mathsf{,}~ [\mathit{lit}~\mathsf{,}]\*\mathsf{)} \\\\
+\mathsf{(}\mathit{lit}~\mathsf{,}~ [\mathit{lit}~\mathsf{,}]*\mathsf{)} \\
 \mathit{range} &::=&
-\mathit{lit}\mathsf{..}\mathit{lit} \\\\&|&
-\mathit{ident} \\\\
+\mathit{lit}\mathsf{..}\mathit{lit} \\&|&
+\mathit{ident} \\
 \mathit{lit} &::=&
-\mathit{bool} \\\\&|&
-\mathit{int} \\\\&|&
-\mathit{float} \\\\&|&
-\mathit{str} \\\\&|&
-\mathit{ident} \\\\
-\\\\
+\mathit{bool} \\&|&
+\mathit{int} \\&|&
+\mathit{float} \\&|&
+\mathit{str} \\&|&
+\mathit{ident} \\
+\\
 \mathit{bool} &::=&
-\mathsf{true}~|~\mathsf{false} \\\\
+\mathsf{true}~|~\mathsf{false} \\
 \mathit{int} &::=&
-/\texttt{[0-9]+}/ \\\\
+/\texttt{[0-9]+}/ \\
 \mathit{float} &::=&
-/\texttt{0[xX]\([0-9a-fA-F]\*\\.[0-9a-fA-F]+\)|\([0-9a-fA-F]+\\.?\)\([pP][+-]?[0-9]+\)?}/ \\\\
+/\texttt{0[xX]\([0-9a-fA-F]*\\.[0-9a-fA-F]+\)|\([0-9a-fA-F]+\\.?\)\([pP][+-]?[0-9]+\)?}/ \\
 \mathit{str} &::=&
-/\texttt{"[\^\"]\*"}/ \\\\
+/\texttt{"[\^\"]*"}/ \\
 \mathit{ident} &::=&
-/\texttt{[A-Za-z]A-Za-z0-9\*]\*}/ \\\\
+/\texttt{[A-Za-z]A-Za-z0-9*]*}/ \\
 \end{array}
-\\]
+\]
+</div>

--- a/docs/src/microzinc/semantics.md
+++ b/docs/src/microzinc/semantics.md
@@ -2,127 +2,154 @@
 
 Note that only function calls and the items in let expressions change the environment.
 
-\\(
+<div>
+\[
 \def\tuple#1{\left\langle #1 \right\rangle}
-\def\Sem#1#2{[\\![#1]\\!]\tuple{#2}}
-\def\SemLet#1#2{[\\![#1]\\!]\_L\tuple{#2}}
+\def\Sem#1#2{[\![#1]\!]\tuple{#2}}
+\def\SemLet#1#2{[\![#1]\!]_L\tuple{#2}}
 \def\Prog\ensuremath{\mathcal{P}}
 \def\Env\ensuremath{\sigma}
-\\)
+\]
+</div>
 
 ### Function calls
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \mathsf{function}~T\mathsf{:}~F\mathsf{(} p*1, \dots, p_k \mathsf{)} = E; \in{} \Prog{},~\text{where the}~p_i~\text{are fresh} $}
 	\AxiomC{$ \Sem{E*{[p_i \mapsto a_i, \forall{} 1 \leq{} i \leq{} k]}}{\Prog, \Env} \Rightarrow{} \tuple{v, \Env'} $}
 	\RightLabel{(E-Call)}
 	\BinaryInfC{$ \Sem{F\mathsf{(}a_1, \ldots, a_k\mathsf{)}}{\Prog, \Env, C} \Rightarrow{} \tuple{v, \Env'} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ F \in \text{Builtins} $}
 \RightLabel{(E-Call-Builtin)}
 \UnaryInfC{$ \Sem{F\mathsf{(}a_1, \ldots, a_k\mathsf{)}}{\Prog, \Env} \Rightarrow{} \tuple{\mathit{eval}(F, \langle a_1, \dots, a_k \rangle), \Env'} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
 TODO: The following rule comes from my thesis to call a native constraint, but I'm not sure if it works correctly when you have a functionally defined Boolean variable (call on RHS).
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \mathsf{function~var~bool:}~F\mathsf{(}p_1, \ldots, p_k\mathsf{)}; \in \Prog $}
 \RightLabel{(E-Call-Native)}
 \UnaryInfC{$ \Sem{F\mathsf{(}a_1, \ldots, a_k\mathsf{)}}{\Prog, \Env} \Rightarrow{} \tuple{\mathsf{constraint}~ F\mathsf{(}a_1, \ldots, a_k\mathsf{)}, \Env} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
 ### Let expressions
 
 Constraint in let-expression are aggregated and bound to the returned variable. As such, let expressions are evaluated with an addition context collection \\( C \\), which contains the constraints enforced in the let-expression. Evaluation rules that use this special context are indicated using \\( L \\).
 
-\\[
+<div>
+\[
 \begin{prooftree}
-\AxiomC{$ \SemLet{\mathsf{let}~\mathsf{\\\{}~items~\mathsf{\\\}}~\mathsf{in}~y}{\Prog, \Env, \emptyset} \Rightarrow \tuple{x, \Env'} $}
+\AxiomC{$ \SemLet{\mathsf{let}~\mathsf{\{}~items~\mathsf{\}}~\mathsf{in}~y}{\Prog, \Env, \emptyset} \Rightarrow \tuple{x, \Env'} $}
 \RightLabel{(E-Let)}
-\UnaryInfC{$ \Sem{\mathsf{let}~\mathsf{\\\{}~items~\mathsf{\\\}}~\mathsf{in}~y}{\Prog, \Env} \Rightarrow{} \tuple{x, \Env'} $}
+\UnaryInfC{$ \Sem{\mathsf{let}~\mathsf{\{}~items~\mathsf{\}}~\mathsf{in}~y}{\Prog, \Env} \Rightarrow{} \tuple{x, \Env'} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Sem{y}{\Prog, \Env} \Rightarrow \tuple{x, \Env} $}
 \RightLabel{(E-Let-In)}
-\UnaryInfC{$ \SemLet{\mathsf{let}~\mathsf{\\\{}\mathsf{\\\}}~\mathsf{in}~y}{\Prog, \Env, C} \Rightarrow{} \tuple{x, \Env \cup x~\texttt{↳}~C\} $}
+\UnaryInfC{$ \SemLet{\mathsf{let}~\mathsf{\{}\mathsf{\}}~\mathsf{in}~y}{\Prog, \Env, C} \Rightarrow{} \tuple{x, \Env \cup x~\texttt{↳}~C} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Sem{E}{\Prog, \Env} \Rightarrow \tuple{c, \Env'} $}
-\AxiomC{$ \SemLet{\mathsf{let}~\mathsf{\\\{}~items~\mathsf{\\\}}~\mathsf{in}~y}{\Prog, \Env', C \cup c} \Rightarrow{} \tuple{x, \Env''\} $}
+\AxiomC{$ \SemLet{\mathsf{let}~\mathsf{\{}~items~\mathsf{\}}~\mathsf{in}~y}{\Prog, \Env', C \cup c} \Rightarrow{} \tuple{x, \Env''} $}
 \RightLabel{(E-Let-Con)}
-\BinaryInfC{$ \SemLet{\mathsf{let}~\mathsf{\\\{}~\mathsf{constraint}~E~\mathsf{;}~items~\mathsf{\\\}}~\mathsf{in}~y}{\Prog, \Env, C} \Rightarrow{} \tuple{x, \Env''\} $}
+\BinaryInfC{$ \SemLet{\mathsf{let}~\mathsf{\{}~\mathsf{constraint}~E~\mathsf{;}~items~\mathsf{\}}~\mathsf{in}~y}{\Prog, \Env, C} \Rightarrow{} \tuple{x, \Env''} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
-\AxiomC{$ \SemLet{\mathsf{let}~\mathsf{\\\{}~items~\mathsf{\\\}}~\mathsf{in}~y}{\Prog, \Env \cup \{T: x\}, C} \Rightarrow{} \tuple{x, \Env'\} $}
+\AxiomC{$ \SemLet{\mathsf{let}~\mathsf{\{}~items~\mathsf{\}}~\mathsf{in}~y}{\Prog, \Env \cup \{T: x\}, C} \Rightarrow{} \tuple{x, \Env'} $}
 \RightLabel{(E-Let-Decl1)}
-\UnaryInfC{$ \SemLet{\mathsf{let}~\mathsf{\\\{}~T~\mathsf{:}~x~\mathsf{;}~items~\mathsf{\\\}}~\mathsf{in}~y}{\Prog, \Env, C} \Rightarrow{} \tuple{x, \Env'\} $}
+\UnaryInfC{$ \SemLet{\mathsf{let}~\mathsf{\{}~T~\mathsf{:}~x~\mathsf{;}~items~\mathsf{\}}~\mathsf{in}~y}{\Prog, \Env, C} \Rightarrow{} \tuple{x, \Env'} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Sem{E}{\Prog, \Env} \Rightarrow \tuple{v, \Env'} $}
-	\AxiomC{$ \SemLet{\mathsf{let}~\mathsf{\\\{}~items*{[x \mapsto v]}~\mathsf{\\\}}~\mathsf{in}~y*{[x \mapsto v]}}{\Prog, \Env', C} \Rightarrow{} \tuple{x, \Env''\} $}
+	\AxiomC{$ \SemLet{\mathsf{let}~\mathsf{\{}~items*{[x \mapsto v]}~\mathsf{\}}~\mathsf{in}~y*{[x \mapsto v]}}{\Prog, \Env', C} \Rightarrow{} \tuple{x, \Env''} $}
 	\RightLabel{(E-Let-Decl2)}
-	\BinaryInfC{$ \SemLet{\mathsf{let}~\mathsf{\\\{}~T~\mathsf{:}~x = E~\mathsf{;}~items~\mathsf{\\\}}~\mathsf{in}~y}{\Prog, \Env, C} \Rightarrow{} \tuple{x, \Env''\} $}
+	\BinaryInfC{$ \SemLet{\mathsf{let}~\mathsf{\{}~T~\mathsf{:}~x = E~\mathsf{;}~items~\mathsf{\}}~\mathsf{in}~y}{\Prog, \Env, C} \Rightarrow{} \tuple{x, \Env''} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
 ### Comprehensions and Generators
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{}
 \RightLabel{(T-Comp-NoGen)}
 \UnaryInfC{$ \Sem{\mathsf{[} E \mathsf{|}~\mathsf{]}}{\Prog,\Env} \Rightarrow{} \tuple{\mathsf{[ ]}, \Env} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Sem{I}{\Prog, \Env} \Rightarrow \tuple{\mathsf{[ ]}, \Env'} $}
 	\RightLabel{(T-Comp-Empty)}
 	\UnaryInfC{$ \Sem{\mathsf{[} E \mathsf{|}~x~\mathsf{in}~I~\mathsf{where}~B, gens~\mathsf{]}}{\Prog,\Env} \Rightarrow{} \tuple{\mathsf{[ ]}, \Env} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Sem{I}{\Prog, \Env} \Rightarrow \tuple{\mathsf{[}v_1~\mathsf{]}, \Env'} $}
 	\RightLabel{(T-Comp-It)}
 	\UnaryInfC{$ \Sem{\mathsf{[} E \mathsf{|}~x~\mathsf{in}~I~\mathsf{where}~B, gens~\mathsf{]}}{\Prog,\Env} \Rightarrow{} \tuple{\mathsf{[ ]}, \Env} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
 ### Tuples and Arrays
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Sem{x}{\Prog,\Env} \Rightarrow{} \tuple{\mathsf{(} v_1\mathsf{,} \dots\mathsf{,} v_n \mathsf{)}, \Env} $}
 \AxiomC{$ i \in 1 \mathsf{..} n$}
 \RightLabel{(E-Tup-Acc)}
 \BinaryInfC{$ \Sem{x \mathsf{.} i}{\Prog,\Env} \Rightarrow{} \tuple{v_i, \Env} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Sem{x}{\Prog,\Env} \Rightarrow{} \tuple{\mathsf{[} v_n\mathsf{,} \dots\mathsf{,} v_m \mathsf{]}, \Env} $}
 	\AxiomC{$ \Sem{y}{\Prog,\Env} \Rightarrow{} \tuple{i, \Env} $}
@@ -130,40 +157,48 @@ Constraint in let-expression are aggregated and bound to the returned variable. 
 	\RightLabel{(E-Arr-Ind)}
 	\TrinaryInfC{$ \Sem{x \mathsf{[} y \mathsf{]}}{\Prog,\Env} \Rightarrow{} \tuple{v_i, \Env} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
 ### If-then-else expressions
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Sem{x_1}{\Prog,\Env} \Rightarrow{} \tuple{\mathsf{true}, \Env} $}
 \AxiomC{$ \Sem{E_1}{\Prog,\Env} \Rightarrow{} \tuple{v, \Env'} $}
 \RightLabel{(E-If)}
 \BinaryInfC{$ \Sem{\mathsf{if}~x_1~\mathsf{then}~E_1~\mathsf{elseif}~x_2~\mathsf{then}~E_2 \dots \mathsf{else}~E_n~\mathsf{endif}}{\Prog,\Env} \Rightarrow{} \tuple{v, \Env'} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Sem{x_1}{\Prog,\Env} \Rightarrow{} \tuple{\mathsf{false}, \Env} $}
 \AxiomC{$ \Sem{\mathsf{if}~x_2~\mathsf{then}~E_2 \dots \mathsf{else}~E_n~\mathsf{endif}}{\Prog,\Env} \Rightarrow{} \tuple{v, \Env'} $}
 \RightLabel{(E-ElseIf)}
 \BinaryInfC{$ \Sem{\mathsf{if}~x_1~\mathsf{then}~E_1~\mathsf{elseif}~x_2~\mathsf{then}~E_2 \dots \mathsf{else}~E_n~\mathsf{endif}}{\Prog,\Env} \Rightarrow{} \tuple{v, \Env'} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Sem{x}{\Prog,\Env} \Rightarrow{} \tuple{\mathsf{false}, \Env} $}
 \AxiomC{$ \Sem{E_2}{\Prog,\Env} \Rightarrow{} \tuple{v, \Env'} $}
 \RightLabel{(E-Else)}
 \BinaryInfC{$ \Sem{\mathsf{if}~x~\mathsf{then}~E_1~\mathsf{else}~E_2~\mathsf{endif}}{\Prog,\Env} \Rightarrow{} \tuple{v, \Env'} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
 ### Identifiers and Literals
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ x \in \mathit{ident} $}
 \AxiomC{$ \{T: x~\texttt{↳}~C \} \in \Env $}
@@ -175,4 +210,5 @@ Constraint in let-expression are aggregated and bound to the returned variable. 
 \RightLabel{(E-Lit)}
 \UnaryInfC{$ \Sem{v}{\Prog, \Env} \Rightarrow{} \tuple{v, \Env} $}
 \end{prooftree}
-\\]
+\]
+</div>

--- a/docs/src/microzinc/types.md
+++ b/docs/src/microzinc/types.md
@@ -2,27 +2,29 @@
 
 The following syntax describes the types available in MicroZinc. The type syntax are used directly in let-expressions and parameter declarations.
 
-\\[
+<div>
+\[
 \begin{array}{lcl}
 \mathit{typeinst} &::=&
-\mathsf{pred} \\\\&|&
-\mathsf{array}~\mathsf{[}\mathit{int}\mathsf{..}\mathit{int} [ \mathsf{,}~ \mathit{int}\mathsf{..}\mathit{int}]\*\mathsf{]}~\mathsf{of}~\mathit{baseType} \\\\&|&
-\mathit{baseType} \\\\
+\mathsf{pred} \\&|&
+\mathsf{array}~\mathsf{[}\mathit{int}\mathsf{..}\mathit{int} [ \mathsf{,}~ \mathit{int}\mathsf{..}\mathit{int}]*\mathsf{]}~\mathsf{of}~\mathit{baseType} \\&|&
+\mathit{baseType} \\
 \mathit{baseType} &::=&
-\mathsf{tuple}~\mathsf{(}\mathit{typeinst} [ \mathsf{,}~ \mathit{typeinst}]\*\mathsf{)} \\\\&|&
-\mathit{domType} \\\\&|&
-\mathit{primType} \\\\
+\mathsf{tuple}~\mathsf{(}\mathit{typeinst} [ \mathsf{,}~ \mathit{typeinst}]*\mathsf{)} \\&|&
+\mathit{domType} \\&|&
+\mathit{primType} \\
 \mathit{domType} &::=&
-\mathsf{var}~\mathit{val}\\\\&|&
-\mathsf{var}~\mathsf{set}~\mathsf{of}~\mathit{val}\\\\
+\mathsf{var}~\mathit{val}\\&|&
+\mathsf{var}~\mathsf{set}~\mathsf{of}~\mathit{val}\\
 \mathit{primType} &::=&
-\mathsf{par}~\mathsf{bool}~|~\mathsf{var}~\mathsf{bool}\\\\&|&
-\mathsf{par}~\mathsf{int}~|~\mathsf{var}~\mathsf{int}\\\\&|&
-\mathsf{par}~\mathsf{float}~|~\mathsf{var}~\mathsf{float}\\\\&|&
-\mathsf{par}~\mathsf{set}~\mathsf{of}~\mathsf{int}~|~\mathsf{var}~\mathsf{set}~\mathsf{of}~\mathsf{int}\\\\&|&
+\mathsf{par}~\mathsf{bool}~|~\mathsf{var}~\mathsf{bool}\\&|&
+\mathsf{par}~\mathsf{int}~|~\mathsf{var}~\mathsf{int}\\&|&
+\mathsf{par}~\mathsf{float}~|~\mathsf{var}~\mathsf{float}\\&|&
+\mathsf{par}~\mathsf{set}~\mathsf{of}~\mathsf{int}~|~\mathsf{var}~\mathsf{set}~\mathsf{of}~\mathsf{int}\\&|&
 \mathsf{par}~\mathsf{set}~\mathsf{of}~\mathsf{float}~|~\mathsf{string}
 \end{array}
-\\]
+\]
+</div>
 
 Importantly, MicroZinc includes two types of sub-typing. When type \\( T_1 \\) is a sub-type of type \\( T_2 \\) then \\( T_1 \\) can be used anywhere where the type \\( T_2 \\) is required.
 
@@ -37,16 +39,19 @@ The following rules describe the conditions under which a MicroZinc program is c
 
 At the top level of the MicroZinc program we find different functions. The program is well-typed if the type of the body of each function matches the declared type of the function given the declared types for the arguments. The types of all functions are available when typing the body expression of a function, allowing for (mutual) recursive functions.
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} T : T^r$}
 \AxiomC{$ \Gamma, f^{id} : (T'_1 \equiv )\langle T^p_1, \dots, T^p_n \rangle \rightarrow T^{r}\vdash{} funcs : \langle T'_2, \dots, T'_m \rangle $}
 \RightLabel{(T-Builtin)}
 \BinaryInfC{$ \vdash{} \mathsf{function}~T~\mathsf{:}~f^{id}~\mathsf{(} T^p_1 : x_1\mathsf{,}\dots\mathsf{,}T^p_n : x_n\mathsf{)}~\mathsf{;} funcs : \langle T'_1, \dots, T'_m \rangle $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} T : T^r$}
 \AxiomC{$ \Gamma, f^{id}_1 : (T'_1 \equiv) \langle T^p_1, \dots, T^p_n \rangle \rightarrow T^r \vdash{} f_2 \mathsf{;} \dots \mathsf{;} f_m : \langle T'_2, \dots, T'_m \rangle $}
@@ -55,17 +60,21 @@ At the top level of the MicroZinc program we find different functions. The progr
 \RightLabel{(T-Func)}
 \UnaryInfC{$ \Gamma \vdash{} \mathsf{function}~T~\mathsf{:}~f^{id}_1~\mathsf{(}~x_1: T^p_1, \dots, x_n: T^p_n \mathsf{)}~\mathsf{=}~E~\mathsf{;} f_2 \mathsf{;} \dots \mathsf{;} f_m : \langle T'_1, \dots, T'_m \rangle $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma, f^{id} : (T'_1 \equiv )\langle T^p_1, \dots, T^p_n \rangle \rightarrow \mathsf{pred}\vdash{} funcs : \langle T'_2, \dots, T'_m \rangle $}
 \RightLabel{(T-Slv-Native)}
 \UnaryInfC{$ \vdash{} \mathsf{predicate}~f^{id}~\mathsf{(} T^p_1 : x_1\mathsf{,}\dots\mathsf{,}T^p_n : x_n\mathsf{)}~\mathsf{;} funcs : \langle T'_1, \dots, T'_m \rangle $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma, f^{id}_1 : (T'_1 \equiv) \langle T^p_1, \dots, T^p_n \rangle \rightarrow \mathsf{pred} \vdash{} f_2 \mathsf{;} \dots \mathsf{;} f_m : \langle T'_2, \dots, T'_m \rangle $}
 \noLine{}
@@ -73,150 +82,180 @@ At the top level of the MicroZinc program we find different functions. The progr
 \RightLabel{(T-Pred)}
 \UnaryInfC{$ \Gamma \vdash{} \mathsf{function}~T~\mathsf{:}~f^{id}_1~\mathsf{(}~x_1: T^p_1, \dots, x_n: T^p_n \mathsf{)}~\mathsf{=}~E~\mathsf{;} f_2 \mathsf{;} \dots \mathsf{;} f_m : \langle T'_1, \dots, T'_m \rangle $}
 \end{prooftree}
-\\]
+\]
+</div>
 
 Calls are defined in both the context of a constraint and on the right hand side of an assignment of a let-expression. In both cases the typing of call is described by the following rule.
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ f^{id} : \langle T^p_1, \dots, T^p_n \rangle \rightarrow T^r \in \Gamma$}
 \AxiomC{$ \Gamma \vdash{} x_1 : T^p_1 ~~ \dots ~~ \Gamma \vdash{} x_n : T^p_n$}
 \RightLabel{(T-Call)}
 \BinaryInfC{$ \Gamma \vdash{} f^{id} ~\mathsf{(}~x_1 \mathsf{,} \dots \mathsf{,} x_n~\mathsf{)} : T^r $}
 \end{prooftree}
-\\]
+\]
+</div>
 
 ### Let expressions and identifiers
 
 Identifiers are typed simply using a lookup in the typing context. The typing of the let expression iteratively adds the types of each declaration item to the typing context. The program is well-typed when all expressions on the right-hand side of a declaration match their declared types, and any constraint items are of \\( \mathsf{pred} \\) type.
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ x : T \in \Gamma $}
 \RightLabel{(T-Ident)}
 \UnaryInfC{$ \Gamma \vdash{} x : T$}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} x : T$}
 \RightLabel{(T-Let-Base)}
-\UnaryInfC{$ \Gamma \vdash{} \mathsf{let}~\mathsf{\\\{}~\mathsf{\\\}}~\mathsf{in}~\mathit{x} : T$}
+\UnaryInfC{$ \Gamma \vdash{} \mathsf{let}~\mathsf{\\{}~\mathsf{\\}}~\mathsf{in}~\mathit{x} : T$}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} T : T'$}
-\AxiomC{$ \Gamma, x : T' \vdash{} \mathsf{let}~\mathsf{\\\{}~items~\mathsf{\\\}}~\mathsf{in}~y : T''$}
+\AxiomC{$ \Gamma, x : T' \vdash{} \mathsf{let}~\mathsf{\\{}~items~\mathsf{\\}}~\mathsf{in}~y : T''$}
 \RightLabel{(T-Let-Decl1)}
-\BinaryInfC{$ \Gamma \vdash{} \mathsf{let}~\mathsf{\\\{}~T~\mathsf{:}~x~\mathsf{;}~items~\mathsf{\\\}}~\mathsf{in}~y : T''$}
+\BinaryInfC{$ \Gamma \vdash{} \mathsf{let}~\mathsf{\\{}~T~\mathsf{:}~x~\mathsf{;}~items~\mathsf{\\}}~\mathsf{in}~y : T''$}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} T : T'$}
 \AxiomC{$ \Gamma \vdash{} E : T'$}
-\AxiomC{$ \Gamma, x : T' \vdash{} \mathsf{let}~\mathsf{\\\{}~items~\mathsf{\\\}}~\mathsf{in}~y : T''$}
+\AxiomC{$ \Gamma, x : T' \vdash{} \mathsf{let}~\mathsf{\\{}~items~\mathsf{\\}}~\mathsf{in}~y : T''$}
 \RightLabel{(T-Let-Decl2)}
-\TrinaryInfC{$ \Gamma \vdash{} \mathsf{let}~\mathsf{\\\{}~T~\mathsf{:}~x = E~\mathsf{;}~items~\mathsf{\\\}}~\mathsf{in}~y : T''$}
+\TrinaryInfC{$ \Gamma \vdash{} \mathsf{let}~\mathsf{\\{}~T~\mathsf{:}~x = E~\mathsf{;}~items~\mathsf{\\}}~\mathsf{in}~y : T''$}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} E : \mathsf{pred}$}
-\AxiomC{$ \Gamma, x : T \vdash{} \mathsf{let}~\mathsf{\\\{}~items~\mathsf{\\\}}~\mathsf{in}~y : T'$}
+\AxiomC{$ \Gamma, x : T \vdash{} \mathsf{let}~\mathsf{\\{}~items~\mathsf{\\}}~\mathsf{in}~y : T'$}
 \RightLabel{(T-Let-Con)}
-\BinaryInfC{$ \Gamma \vdash{} \mathsf{let}~\mathsf{\\\{}~\mathsf{constraint}~E~\mathsf{;}~items~\mathsf{\\\}}~\mathsf{in}~y : T'$}
+\BinaryInfC{$ \Gamma \vdash{} \mathsf{let}~\mathsf{\\{}~\mathsf{constraint}~E~\mathsf{;}~items~\mathsf{\\}}~\mathsf{in}~y : T'$}
 \end{prooftree}
-\\]
+\]
+</div>
 
 ### Comprehensions and Generators
 
 As shown in the following rules, the \\( \mathit{genExpr} \\) rules will must have either type \\( \mathsf{set~of~int} \\) or \\( \mathsf{array1d~of}~T \\). The \\( \text{T_Comp} \\) rule, to type array comprehensions, will use the \\( elem \\) function which maps the former type to \\( \mathsf{int} \\) and the latter to \\( T \\).
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma, \vdash{} E : T$}
 	\RightLabel{(T-Comp-Expr)}
 	\UnaryInfC{$ \Gamma \vdash{} \mathsf{[} E~\mathsf{|}~\mathsf{]} : \mathsf{array1d~of~} T $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} I : T$}
-	\AxiomC{$ T \in \\{ \mathsf{set~of~int}, \mathsf{array1d~of}~V \\}$}
+	\AxiomC{$ T \in \{ \mathsf{set~of~int}, \mathsf{array1d~of}~V \}$}
 	\AxiomC{$ \Gamma, x : T \vdash{} \mathsf{[} E~\mathsf{|}~gens~\mathsf{]} : T' $}
 	\RightLabel{(T-Comp-In)}
 	\TrinaryInfC{$ \Gamma \vdash{} \mathsf{[} E~\mathsf{|}~x~\mathsf{in}~I, gens~\mathsf{]} : T' $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} B : \mathsf{par~bool}$}
 	\AxiomC{$ \Gamma \vdash{} \mathsf{[} E~\mathsf{|}~x~\mathsf{in}~I, gens~\mathsf{]} : T $}
 	\RightLabel{(T-Comp-Where)}
 	\BinaryInfC{$ \Gamma \vdash{} \mathsf{[} E~\mathsf{|}~x~\mathsf{in}~I~\mathsf{where}~B, gens~\mathsf{]} : T $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} E_2 : T$}
 	\AxiomC{$ \Gamma, x : T \vdash{} \mathsf{[} E_1~\mathsf{|}~gens~\mathsf{]} : T' $}
 	\RightLabel{(T-Comp-Asg)}
 	\BinaryInfC{$ \Gamma \vdash{} \mathsf{[} E_1~\mathsf{|}~x~\mathsf{=}~E_2, gens~\mathsf{]} : T' $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma\vdash{} \mathsf{[} I_i~\mathsf{|}~gens~\mathsf{]} : \mathsf{array1d~of~int}, \forall{} 1 \leq{} i \leq{} X$}
 	\AxiomC{$ \Gamma\vdash{} \mathsf{[} E~\mathsf{|}~gens~\mathsf{]} : \mathsf{array1d~of}~T $}
 	\RightLabel{(T-Comp-Ind)}
 	\BinaryInfC{$ \Gamma \vdash{} \mathsf{[(}I_1, \dots, I_X \mathsf{):} E~\mathsf{|}gens~\mathsf{]} : \mathsf{array}X\mathsf{d~of}~T $}
 \end{prooftree}
-\\]
+\]
+</div>
 
 ### Arrays, Sets, and Tuples
 
 MicroZinc has three different container types. Arrays can contain multiple, possibly duplicate, elements of the same type, each associated with a unique index with which the element can be retrieved.
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} r_i : \mathsf{par~set~of~int}, \forall{} 1 \leq{} i \leq{} X$}
 	\AxiomC{$ \Gamma \vdash{} x_i : T, \forall{} 1 \leq{} i \leq{} n$}
 	\RightLabel{(T-Arr)}
 	\BinaryInfC{$ \Gamma \vdash{} \mathsf{array}X\mathsf{d(}~r_1 \mathsf{,} \dots \mathsf{,} r_X \mathsf{,} \mathsf{[} x_1 \mathsf{,} \dots \mathsf{,} x_n \mathsf{])} : \mathsf{array}X\mathsf{d~of}~T $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} v_i : \mathsf{par}~\mathsf{int}, \forall{} 1 \leq{} i \leq{} X$}
 	\AxiomC{$ \Gamma \vdash{} x : \mathsf{array}X\mathsf{d~of}~T$}
 	\RightLabel{(T-Ind)}
 	\BinaryInfC{$ \Gamma \vdash{} x \mathsf{[} v_1 \mathsf{,} \dots \mathsf{,} v_X \mathsf{]} : T $}
 \end{prooftree}
-\\]
+\]
+</div>
 
 Sets contain a certain number of unique elements of the same type. Ranges of elements are also typed as sets.
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} x_1 : T, \forall{} 1 \leq{} i \leq{} n$}
 \AxiomC{$ T \in {\mathsf{par~int}, \mathsf{par~float}}$}
 \RightLabel{(T-Set)}
-\BinaryInfC{$ \Gamma \vdash{} \mathsf{\\{} x_1 \mathsf{,} \dots \mathsf{,} x_n \mathsf{\\}} : \mathsf{par~set~of}~T $}
+\BinaryInfC{$ \Gamma \vdash{} \mathsf{\{} x_1 \mathsf{,} \dots \mathsf{,} x_n \mathsf{\}} : \mathsf{par~set~of}~T $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} x_1 : T $}
 \AxiomC{$ \Gamma \vdash{} x_2 : T $}
@@ -224,29 +263,36 @@ Sets contain a certain number of unique elements of the same type. Ranges of ele
 \RightLabel{(T-Range)}
 \TrinaryInfC{$ \Gamma \vdash{} x_1 \mathsf{..} x_2 : \mathsf{par~set~of}~T $}
 \end{prooftree}
-\\]
+\]
+</div>
 
 Finally, tuples are collections of elements with possibly different types. The number of elements in a tuple is known during type checking
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} x_i : T_i, \forall{} 1 \leq{} i \leq{} n$}
 \RightLabel{(T-Tup)}
 \UnaryInfC{$ \Gamma \vdash{} \mathsf{(} x_1\mathsf{,} \dots\mathsf{,} x_n \mathsf{)} : \mathsf{tuple(} T_1 \mathsf{,} \dots \mathsf{,} T_n \mathsf{)}$}
 \end{prooftree}
-\\]
-\\[
+\]
+</div>
+
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} x : \mathsf{tuple(} T_1 \mathsf{,} \dots \mathsf{,} T_i \mathsf{,} \dots \mathsf{,} T_n \mathsf{)}$}
 \AxiomC{$ i \in 1 \mathsf{..} n $}
 \RightLabel{(T-Acc)}
 \BinaryInfC{$ \Gamma \vdash{} x \mathsf{.} i : T_i $}
 \end{prooftree}
-\\]
+\]
+</div>
 
 ### If-then-else Expressions
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} x : \mathsf{par}~\mathsf{bool} $}
 \AxiomC{$ \Gamma \vdash{} E_1 : T$}
@@ -254,9 +300,11 @@ Finally, tuples are collections of elements with possibly different types. The n
 \RightLabel{(T-If)}
 \TrinaryInfC{$ \Gamma \vdash{} \mathsf{if}~x~\mathsf{then}~E_1~\mathsf{else}~E_2~\mathsf{endif} : T $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} x_1 : \mathsf{par}~\mathsf{bool} $}
 \AxiomC{$ \Gamma \vdash{} E_1 : T$}
@@ -264,13 +312,15 @@ Finally, tuples are collections of elements with possibly different types. The n
 \RightLabel{(T-ElseIf)}
 \TrinaryInfC{$ \Gamma \vdash{} \mathsf{if}~x_1~\mathsf{then}~E_1~\mathsf{elseif}~x_2~\mathsf{then}~E_2 \dots \mathsf{else}~E_n~\mathsf{endif} : T $}
 \end{prooftree}
-\\]
+\]
+</div>
 
 ### Literals
 
 The remaining parts of the MicroZinc laguage are simple literals that have an intrinsic type.
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{}
 \RightLabel{(T-Root)}
@@ -286,8 +336,11 @@ The remaining parts of the MicroZinc laguage are simple literals that have an in
 \RightLabel{(T-False)}
 \UnaryInfC{$\vdash{} \mathsf{false} : \mathsf{par}~\mathsf{bool}$}
 \end{prooftree}
-\\]
-\\[
+\]
+</div>
+
+<div>
+\[
 \begin{prooftree}
 \AxiomC{}
 \RightLabel{(T-int)}
@@ -296,37 +349,46 @@ The remaining parts of the MicroZinc laguage are simple literals that have an in
 \begin{prooftree}
 \AxiomC{}
 \RightLabel{(T-Str)}
-\UnaryInfC{$\vdash{} /\texttt{"[\^\"]\*"}/ : \mathsf{string}$}
+\UnaryInfC{$\vdash{} /\texttt{"[\^\"]*"}/ : \mathsf{string}$}
 \end{prooftree}
-\\]
-\\[
+\]
+</div>
+
+<div>
+\[
 \begin{prooftree}
 \AxiomC{}
 \RightLabel{(T-float)}
-\UnaryInfC{$\vdash{} /\texttt{0[xX]\([0-9a-fA-F]\*\\.[0-9a-fA-F]+\)|\([0-9a-fA-F]+\\.?\)\([pP][+-]?[0-9]+\)?}/ : \mathsf{par}~\mathsf{float}$}
+\UnaryInfC{$\vdash{} /\texttt{0[xX]\\([0-9a-fA-F]*\\.[0-9a-fA-F]+\\)|\\([0-9a-fA-F]+\\.?\\)\\([pP][+-]?[0-9]+\\)?}/ : \mathsf{par}~\mathsf{float}$}
 \end{prooftree}
-\\]
+\]
+</div>
 
 ### Type Instances
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} I_i : \mathsf{par}~\mathsf{set}~\mathsf{of}~\mathsf{int}, \forall{} 1 \leq{} i \leq{} X$}
 	\AxiomC{$ \Gamma \vdash{} T : T'$}
 	\RightLabel{(T-Type-Arr)}
 	\BinaryInfC{$ \Gamma \vdash{} \mathsf{array}~\mathsf{[}I_1 \mathsf{,} \dots, I_X\mathsf{]}~\mathsf{of}~\mathit{T} : \mathsf{array}X\mathsf{d~of}~T' $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} T_1 : T'_1 ~~ \dots ~~ \Gamma \vdash{} T_n : T'_n$}
 \RightLabel{(T-Type-Tup)}
 \UnaryInfC{$ \Gamma \vdash{} \mathsf{tuple}\mathsf{(}\mathit{T_1}\mathsf{,} \dots, T_n\mathsf{)} : \mathsf{tuple(}T'_1, \dots, T'_n\mathsf{)} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} S : \mathsf{par}~\mathsf{set}~\mathsf{of}~\mathsf{int}$}
 \RightLabel{(T-Int-Dom)}
@@ -337,14 +399,17 @@ The remaining parts of the MicroZinc laguage are simple literals that have an in
 \RightLabel{(T-Flt-Dom)}
 \UnaryInfC{$ \Gamma \vdash{} \mathsf{var}~S : \mathsf{var}~\mathsf{float} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
-\\[
+<div>
+\[
 \begin{prooftree}
 \AxiomC{$ \Gamma \vdash{} S : \mathsf{par}~\mathsf{set}~\mathsf{of}~\mathsf{int}$}
 \RightLabel{(T-Set-Dom)}
 \UnaryInfC{$ \Gamma \vdash{} \mathsf{var}~\mathsf{set}~\mathsf{of}~S : \mathsf{var}~\mathsf{set}~\mathsf{of}~\mathsf{int} $}
 \end{prooftree}
-\\]
+\]
+</div>
 
 The remaining variants (\\( \mathit{primType} \\)) are trivial, and their expression directly describes their type.

--- a/parsers/tree-sitter-minizinc/bindings/rust/lib.rs
+++ b/parsers/tree-sitter-minizinc/bindings/rust/lib.rs
@@ -43,6 +43,9 @@ pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
 /// Get identifier names
 pub const IDENTIFIERS_QUERY: &str = include_str!("../../queries/identifiers.scm");
 
+/// Get case expressions
+pub const CASE_EXPRESSION_QUERY: &str = include_str!("../../queries/case_expressions.scm");
+
 #[cfg(test)]
 mod tests {
 	#[test]

--- a/parsers/tree-sitter-minizinc/queries/case_expressions.scm
+++ b/parsers/tree-sitter-minizinc/queries/case_expressions.scm
@@ -1,0 +1,1 @@
+(case_expression) @case


### PR DESCRIPTION
- Uses [stacker](https://github.com/rust-lang/stacker) to switch to a virtual stack when there's not much stack space left in recursive functions
- Rewrites more functions to be iterative where it's easy to do so
- Adds better logging of the HIR phase