### PR TITLE
Format `use` statements with nightly rustfmt

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -3,7 +3,8 @@ name: Check Format
 on: [push, pull_request]
 
 env:
-  RUST_CHANNEL: stable
+  # Lets us format with unstable rustfmt options
+  RUST_CHANNEL: nightly
 
 jobs:
   check_format:
@@ -17,8 +18,8 @@ jobs:
         run: |
           rustup toolchain install --profile minimal --component rustfmt --no-self-update ${{ env.RUST_CHANNEL }}
           rustup default ${{ env.RUST_CHANNEL }}
-      - name: Run cargo check
-        run: cargo fmt --all --check
+      - name: Run cargo format
+        run: cargo +nightly fmt --all --check
 
       # Check formatting of other files
       - name: Setup Node.js

--- a/crates/shackle-cli/src/main.rs
+++ b/crates/shackle-cli/src/main.rs
@@ -4,19 +4,14 @@
 #![warn(unused_crate_dependencies, unused_extern_crates)]
 #![warn(variant_size_differences)]
 
+use std::{ffi::OsStr, fs::File, ops::Deref, panic, path::PathBuf};
+
 use clap::{crate_version, Args, Parser, Subcommand};
 use env_logger::{fmt::TimestampPrecision, Builder};
 use humantime::Duration;
 use log::warn;
 use miette::{IntoDiagnostic, Report, Result};
-use shackle::error::InternalError;
-use shackle::{Error, Message, Model, Solver, Status};
-
-use std::ffi::OsStr;
-use std::fs::File;
-use std::ops::Deref;
-use std::panic;
-use std::path::PathBuf;
+use shackle::{error::InternalError, Error, Message, Model, Solver, Status};
 
 /// The main function is the entry point for the `shackle` executable.
 ///

--- a/crates/shackle-compiler/src/constants/ids.rs
+++ b/crates/shackle-compiler/src/constants/ids.rs
@@ -1,5 +1,4 @@
-use crate::hir::db::Hir;
-use crate::hir::Identifier;
+use crate::hir::{db::Hir, Identifier};
 
 macro_rules! id_registry {
 	($struct:ident, $($tail:tt)*) => {

--- a/crates/shackle-compiler/src/constants/tys.rs
+++ b/crates/shackle-compiler/src/constants/tys.rs
@@ -1,5 +1,4 @@
-use crate::db::Interner;
-use crate::ty::Ty;
+use crate::{db::Interner, ty::Ty};
 
 macro_rules! type_registry {
 	($struct:ident, $db:ident, $($name:ident: $value:expr),+$(,)?) => {

--- a/crates/shackle-compiler/src/db.rs
+++ b/crates/shackle-compiler/src/db.rs
@@ -3,21 +3,22 @@
 //! Compiler query database
 //!
 
-use super::hir::db::HirStorage;
-use super::syntax::db::SourceParserStorage;
-use super::thir::db::ThirStorage;
-use crate::constants::TypeRegistry;
-use crate::diagnostics::FileError;
-use crate::file::{DefaultFileHandler, FileHandler, FileRef, FileRefData, InputFile, ModelRef};
-use crate::hir::db::Hir;
-use crate::syntax::db::SourceParser;
-use crate::thir::db::Thir;
-use crate::ty::{NewType, NewTypeData, Ty, TyData};
+use std::{
+	fmt::Display,
+	panic::RefUnwindSafe,
+	path::{Path, PathBuf},
+	sync::Arc,
+};
 
-use std::fmt::Display;
-use std::panic::RefUnwindSafe;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use crate::{
+	constants::TypeRegistry,
+	diagnostics::FileError,
+	file::{DefaultFileHandler, FileHandler, FileRef, FileRefData, InputFile, ModelRef},
+	hir::db::{Hir, HirStorage},
+	syntax::db::{SourceParser, SourceParserStorage},
+	thir::db::{Thir, ThirStorage},
+	ty::{NewType, NewTypeData, Ty, TyData},
+};
 
 /// Queries for inputs
 #[salsa::query_group(InputsStorage)]

--- a/crates/shackle-compiler/src/diagnostics/error.rs
+++ b/crates/shackle-compiler/src/diagnostics/error.rs
@@ -1,15 +1,16 @@
 //! Error handling
 
+use std::{
+	fmt::{Display, Formatter},
+	panic::Location,
+	path::PathBuf,
+};
+
 use miette::{Diagnostic, SourceOffset, SourceSpan};
 use thiserror::Error;
 
-use std::fmt::{Display, Formatter};
-use std::panic::Location;
-use std::path::PathBuf;
-
-use crate::file::SourceFile;
-
 use super::Diagnostics;
+use crate::file::SourceFile;
 
 /// An error internal to Shackle.
 ///

--- a/crates/shackle-compiler/src/file.rs
+++ b/crates/shackle-compiler/src/file.rs
@@ -2,8 +2,6 @@
 //!
 //! `FileRef` is an interned data structure used to represent a pointer to a file (or inline string).
 
-use crate::{db::FileReader, diagnostics::FileError};
-use miette::{MietteSpanContents, SourceCode};
 use std::{
 	fs::read_to_string,
 	ops::Deref,
@@ -11,6 +9,10 @@ use std::{
 	path::{Path, PathBuf},
 	sync::Arc,
 };
+
+use miette::{MietteSpanContents, SourceCode};
+
+use crate::{db::FileReader, diagnostics::FileError};
 
 /// Input files
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/shackle-compiler/src/hir/db.rs
+++ b/crates/shackle-compiler/src/hir/db.rs
@@ -2,26 +2,29 @@
 
 //! Salsa database for HIR operations
 
-use std::collections::HashSet;
-use std::path::Path;
-use std::sync::Arc;
+use std::{collections::HashSet, path::Path, sync::Arc};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::constants::IdentifierRegistry;
-use crate::db::{CompilerSettings, FileReader, Interner, Upcast};
-use crate::diagnostics::{Diagnostics, IncludeError, MultipleErrors};
-use crate::file::{FileRef, ModelRef, SourceFile};
-use crate::syntax::ast::{self, AstNode};
-use crate::syntax::db::SourceParser;
-use crate::ty::EnumRef;
-use crate::{Error, Result, Warning};
-
-use super::ids::{EntityRef, EntityRefData, ItemRef, ItemRefData, PatternRef};
-use super::scope::{ScopeData, ScopeResult};
-use super::source::SourceMap;
-use super::typecheck::{BodyTypes, SignatureTypes, TypeDiagnostics, TypeResult};
-use super::{Identifier, Model, ScopeCollectorResult};
+use super::{
+	ids::{EntityRef, EntityRefData, ItemRef, ItemRefData, PatternRef},
+	scope::{ScopeData, ScopeResult},
+	source::SourceMap,
+	typecheck::{BodyTypes, SignatureTypes, TypeDiagnostics, TypeResult},
+	Identifier, Model, ScopeCollectorResult,
+};
+use crate::{
+	constants::IdentifierRegistry,
+	db::{CompilerSettings, FileReader, Interner, Upcast},
+	diagnostics::{Diagnostics, IncludeError, MultipleErrors},
+	file::{FileRef, ModelRef, SourceFile},
+	syntax::{
+		ast::{self, AstNode},
+		db::SourceParser,
+	},
+	ty::EnumRef,
+	Error, Result, Warning,
+};
 
 /// HIR queries
 #[salsa::query_group(HirStorage)]

--- a/crates/shackle-compiler/src/hir/expression.rs
+++ b/crates/shackle-compiler/src/hir/expression.rs
@@ -4,14 +4,13 @@
 
 use std::fmt;
 
-use crate::utils::{arena::ArenaIndex, impl_enum_from};
-
 use super::{
 	ArrayAccess, ArrayComprehension, ArrayLiteral, ArrayLiteral2D, BooleanLiteral, Constraint,
 	Declaration, FloatLiteral, Generator, Identifier, IndexedArrayLiteral, IntegerLiteral,
 	ItemData, MaybeIndexSet, Parameter, Pattern, RecordLiteral, SetComprehension, SetLiteral,
 	StringLiteral, TupleLiteral, Type,
 };
+use crate::utils::{arena::ArenaIndex, impl_enum_from};
 
 /// An expression
 #[derive(Clone, Hash, PartialEq, Eq)]

--- a/crates/shackle-compiler/src/hir/ids.rs
+++ b/crates/shackle-compiler/src/hir/ids.rs
@@ -4,15 +4,14 @@ use std::sync::Arc;
 
 use miette::SourceSpan;
 
-use crate::{
-	file::{ModelRef, SourceFile},
-	utils::{arena::ArenaIndex, impl_enum_from, DebugPrint},
-};
-
 use super::{
 	db::Hir, Annotation, Assignment, Constraint, Declaration, EnumAssignment, Enumeration,
 	Expression, Function, Identifier, Item, ItemData, Model, Output, Pattern, Solve, Type,
 	TypeAlias,
+};
+use crate::{
+	file::{ModelRef, SourceFile},
+	utils::{arena::ArenaIndex, impl_enum_from, DebugPrint},
 };
 
 /// Reference to an item local to a model.

--- a/crates/shackle-compiler/src/hir/item.rs
+++ b/crates/shackle-compiler/src/hir/item.rs
@@ -14,16 +14,16 @@
 //! changed when modified, so always causes all items in that file to be lowered
 //! again (but not ones in other files).
 
-use std::fmt::Write;
-use std::ops::{Deref, DerefMut};
+use std::{
+	fmt::Write,
+	ops::{Deref, DerefMut},
+};
 
+use super::{db::Hir, source::Origin, Expression, Pattern, Type};
 use crate::utils::{
 	arena::{Arena, ArenaIndex, ArenaMap},
 	debug_print_strings, impl_enum_from, impl_index, DebugPrint,
 };
-
-use super::db::Hir;
-use super::{source::Origin, Expression, Pattern, Type};
 
 /// An item with its data
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/shackle-compiler/src/hir/lower/expression.rs
+++ b/crates/shackle-compiler/src/hir/lower/expression.rs
@@ -4,13 +4,11 @@ use crate::{
 	constants::IdentifierRegistry,
 	db::InternedStringData,
 	diagnostics::{InvalidArrayLiteral, InvalidNumericLiteral, SyntaxError},
-	hir::source::Origin,
+	hir::{db::Hir, source::Origin, *},
 	syntax::ast::{self, AstNode},
 	utils::{arena::ArenaIndex, maybe_grow_stack},
 	Error,
 };
-
-use crate::hir::{db::Hir, *};
 
 /// Collects AST expressions for owned by an item and lowers them into HIR recursively.
 pub struct ExpressionCollector<'a> {

--- a/crates/shackle-compiler/src/hir/lower/item.rs
+++ b/crates/shackle-compiler/src/hir/lower/item.rs
@@ -1,16 +1,19 @@
 use std::sync::Arc;
 
-use crate::constants::IdentifierRegistry;
-use crate::diagnostics::SyntaxError;
-use crate::file::ModelRef;
-use crate::hir::db::Hir;
-use crate::hir::ids::ItemRef;
-use crate::hir::source::{Origin, SourceMap};
-use crate::hir::*;
-use crate::syntax::ast::{self, AstNode};
-use crate::Error;
-
 use super::{ExpressionCollector, TypeInstIdentifiers};
+use crate::{
+	constants::IdentifierRegistry,
+	diagnostics::SyntaxError,
+	file::ModelRef,
+	hir::{
+		db::Hir,
+		ids::ItemRef,
+		source::{Origin, SourceMap},
+		*,
+	},
+	syntax::ast::{self, AstNode},
+	Error,
+};
 
 /// Lower a model to HIR
 pub fn lower_items(db: &dyn Hir, model: ModelRef) -> (Arc<Model>, Arc<SourceMap>, Arc<Vec<Error>>) {

--- a/crates/shackle-compiler/src/hir/lower/mod.rs
+++ b/crates/shackle-compiler/src/hir/lower/mod.rs
@@ -20,8 +20,7 @@
 mod expression;
 mod item;
 
-pub use self::expression::*;
-pub use self::item::*;
+pub use self::{expression::*, item::*};
 
 #[cfg(test)]
 mod test;

--- a/crates/shackle-compiler/src/hir/mod.rs
+++ b/crates/shackle-compiler/src/hir/mod.rs
@@ -39,12 +39,11 @@ pub use scope::*;
 pub use typecheck::*;
 pub use types::*;
 
+use self::ids::LocalItemRef;
 use crate::utils::{
 	arena::{Arena, ArenaIndex},
 	impl_index,
 };
-
-use self::ids::LocalItemRef;
 
 /// A model (a single `.mzn` file)
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/crates/shackle-compiler/src/hir/pattern.rs
+++ b/crates/shackle-compiler/src/hir/pattern.rs
@@ -2,8 +2,10 @@
 //!
 
 use super::{db::Hir, BooleanLiteral, FloatLiteral, IntegerLiteral, ItemData, StringLiteral};
-use crate::db::{InternedString, InternedStringData};
-use crate::utils::{arena::ArenaIndex, impl_enum_from, pretty_print_identifier};
+use crate::{
+	db::{InternedString, InternedStringData},
+	utils::{arena::ArenaIndex, impl_enum_from, pretty_print_identifier},
+};
 
 /// A pattern for destructuring
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]

--- a/crates/shackle-compiler/src/hir/pattern_matching.rs
+++ b/crates/shackle-compiler/src/hir/pattern_matching.rs
@@ -6,19 +6,18 @@ use std::sync::Arc;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use super::{
+	db::Hir,
+	ids::{EntityRef, ItemRef, NodeRef, PatternRef},
+	BooleanLiteral, Expression, FloatLiteral, Identifier, IntegerLiteral, ItemData, OptType,
+	Pattern, PatternTy, StringLiteral, TypeResult,
+};
 use crate::{
 	constants::TypeRegistry,
 	diagnostics::{NonExhaustivePatternMatching, UnreachablePattern, Warning},
 	ty::{EnumRef, Ty, TyData},
 	utils::arena::ArenaIndex,
 	Error,
-};
-
-use super::{
-	db::Hir,
-	ids::{EntityRef, ItemRef, NodeRef, PatternRef},
-	BooleanLiteral, Expression, FloatLiteral, Identifier, IntegerLiteral, ItemData, OptType,
-	Pattern, PatternTy, StringLiteral, TypeResult,
 };
 
 /// Compute a mapping from (non-introduced) enum types to the constructors for the enum

--- a/crates/shackle-compiler/src/hir/primitive.rs
+++ b/crates/shackle-compiler/src/hir/primitive.rs
@@ -1,9 +1,9 @@
 //! HIR representation of primitive values
 //!
-use crate::db::{InternedString, InternedStringData};
+use std::fmt;
 
 use super::{db::Hir, Identifier};
-use std::fmt;
+use crate::db::{InternedString, InternedStringData};
 
 /// An integer literal
 #[derive(Copy, Clone, Default, Debug, Hash, PartialEq, Eq)]

--- a/crates/shackle-compiler/src/hir/scope.rs
+++ b/crates/shackle-compiler/src/hir/scope.rs
@@ -7,6 +7,7 @@ use std::{collections::hash_map::Entry, fmt::Debug, sync::Arc};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use super::{Constructor, EnumConstructor, Generator, MaybeIndexSet};
 use crate::{
 	diagnostics::{IdentifierAlreadyDefined, IdentifierShadowing, InvalidPattern},
 	hir::{
@@ -20,8 +21,6 @@ use crate::{
 	},
 	Error, Result, Warning,
 };
-
-use super::{Constructor, EnumConstructor, Generator, MaybeIndexSet};
 
 /// Gets all variables in global scope.
 ///

--- a/crates/shackle-compiler/src/hir/source.rs
+++ b/crates/shackle-compiler/src/hir/source.rs
@@ -8,16 +8,15 @@ use rustc_hash::FxHashMap;
 use tree_sitter::Node;
 pub use tree_sitter::Point;
 
-use crate::{
-	file::{FileRef, SourceFile},
-	syntax::{ast::*, cst::CstNode},
-	utils::{debug_print_strings, DebugPrint},
-};
-
 use super::{
 	db::Hir,
 	ids::{EntityRef, ExpressionRef, ItemRef, LocalEntityRef, NodeRef},
 	ItemDataSourceMap, Type,
+};
+use crate::{
+	file::{FileRef, SourceFile},
+	syntax::{ast::*, cst::CstNode},
+	utils::{debug_print_strings, DebugPrint},
 };
 
 /// Source mapping between HIR and AST nodes.

--- a/crates/shackle-compiler/src/hir/typecheck/body.rs
+++ b/crates/shackle-compiler/src/hir/typecheck/body.rs
@@ -6,6 +6,7 @@
 /// - Bodies of functions
 use rustc_hash::FxHashMap;
 
+use super::{PatternTy, TypeContext, Typer};
 use crate::{
 	hir::{
 		db::Hir,
@@ -16,8 +17,6 @@ use crate::{
 	utils::arena::{ArenaIndex, ArenaMap},
 	Error,
 };
-
-use super::{PatternTy, TypeContext, Typer};
 
 /// Collected types for an item body
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/shackle-compiler/src/hir/typecheck/mod.rs
+++ b/crates/shackle-compiler/src/hir/typecheck/mod.rs
@@ -36,6 +36,11 @@ use std::{
 	sync::Arc,
 };
 
+use super::{
+	db::Hir,
+	ids::{ExpressionRef, ItemRef, LocalItemRef, PatternRef},
+	Expression, ItemData, Pattern,
+};
 use crate::{
 	ty::{FunctionEntry, Ty, TyData, TyVar},
 	utils::{
@@ -45,21 +50,12 @@ use crate::{
 	Error,
 };
 
-use super::{
-	db::Hir,
-	ids::{ExpressionRef, ItemRef, LocalItemRef, PatternRef},
-	Expression, ItemData, Pattern,
-};
-
 mod body;
 mod signature;
 mod toposort;
 mod typer;
 
-pub use self::body::*;
-pub use self::signature::*;
-pub use self::toposort::*;
-pub use self::typer::*;
+pub use self::{body::*, signature::*, toposort::*, typer::*};
 
 /// Collected types for an item
 ///

--- a/crates/shackle-compiler/src/hir/typecheck/signature.rs
+++ b/crates/shackle-compiler/src/hir/typecheck/signature.rs
@@ -5,6 +5,7 @@
 /// - Variable declaration LHS types
 use rustc_hash::FxHashMap;
 
+use super::{EnumConstructorEntry, PatternTy, TypeCompletionMode, TypeContext, Typer};
 use crate::{
 	diagnostics::{SyntaxError, TypeInferenceFailure, TypeMismatch},
 	hir::{
@@ -18,8 +19,6 @@ use crate::{
 	},
 	Error,
 };
-
-use super::{EnumConstructorEntry, PatternTy, TypeCompletionMode, TypeContext, Typer};
 
 /// Collected types for an item signature
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/shackle-compiler/src/hir/typecheck/toposort.rs
+++ b/crates/shackle-compiler/src/hir/typecheck/toposort.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use super::PatternTy;
 use crate::{
 	diagnostics::CyclicDefinition,
 	hir::{
@@ -21,8 +22,6 @@ use crate::{
 	utils::DebugPrint,
 	Error,
 };
-
-use super::PatternTy;
 
 /// Topologically sort items
 pub fn topological_sort(db: &dyn Hir) -> (Arc<Vec<ItemRef>>, Arc<Vec<Error>>) {

--- a/crates/shackle-compiler/src/hir/typecheck/typer.rs
+++ b/crates/shackle-compiler/src/hir/typecheck/typer.rs
@@ -1,6 +1,8 @@
-use rustc_hash::FxHashMap;
 use std::{collections::hash_map::Entry, fmt::Write, sync::Arc};
 
+use rustc_hash::FxHashMap;
+
+use super::{PatternTy, TypeContext};
 use crate::{
 	constants::{IdentifierRegistry, TypeRegistry},
 	diagnostics::{
@@ -22,8 +24,6 @@ use crate::{
 	utils::{arena::ArenaIndex, maybe_grow_stack},
 	Error,
 };
-
-use super::{PatternTy, TypeContext};
 
 /// Mode for completing types
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/shackle-compiler/src/hir/types.rs
+++ b/crates/shackle-compiler/src/hir/types.rs
@@ -2,11 +2,9 @@
 //!
 //! See the `typecheck` module for computing types.
 
-use crate::utils::arena::ArenaIndex;
-
 use super::{Expression, ItemData, Pattern};
-
 pub use crate::syntax::ast::{OptType, PrimitiveType, VarType};
+use crate::utils::arena::ArenaIndex;
 
 /// Type of an expression
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]

--- a/crates/shackle-compiler/src/hir/validate.rs
+++ b/crates/shackle-compiler/src/hir/validate.rs
@@ -11,6 +11,11 @@ use std::{collections::hash_map::Entry, sync::Arc};
 
 use rustc_hash::FxHashMap;
 
+use super::{
+	db::Hir,
+	ids::{EntityRef, LocalItemRef},
+	PatternTy,
+};
 use crate::{
 	diagnostics::{
 		AdditionalSolveItem, ConstructorAlreadyDefined, DuplicateAssignment, DuplicateConstructor,
@@ -20,12 +25,6 @@ use crate::{
 	hir::ids::{ItemRef, NodeRef},
 	ty::{FunctionEntry, OverloadingError},
 	Error,
-};
-
-use super::{
-	db::Hir,
-	ids::{EntityRef, LocalItemRef},
-	PatternTy,
 };
 
 /// Validate HIR

--- a/crates/shackle-compiler/src/lib.rs
+++ b/crates/shackle-compiler/src/lib.rs
@@ -1,4 +1,6 @@
-//! Shackle library
+//! Shackle internal compiler library.
+//!
+//! This library is considered internal and no stability guarantees are given.
 
 #![warn(missing_docs)]
 #![warn(unused_crate_dependencies, unused_extern_crates)]
@@ -15,14 +17,11 @@ pub mod thir;
 pub mod ty;
 pub mod utils;
 
-pub use diagnostics::Error;
-// Export OptType enumeration used in [`Type`]
-pub use ty::OptType;
+pub use db::CompilerDatabase;
+pub use diagnostics::{Error, Warning};
 
 /// Result type for Shackle operations
 pub type Result<T, E = Error> = std::result::Result<T, E>;
-
-pub use diagnostics::Warning;
 
 #[cfg(test)]
 mod tests {}

--- a/crates/shackle-compiler/src/lib.rs
+++ b/crates/shackle-compiler/src/lib.rs
@@ -16,7 +16,6 @@ pub mod ty;
 pub mod utils;
 
 pub use diagnostics::Error;
-
 // Export OptType enumeration used in [`Type`]
 pub use ty::OptType;
 

--- a/crates/shackle-compiler/src/mir/mod.rs
+++ b/crates/shackle-compiler/src/mir/mod.rs
@@ -2,13 +2,13 @@
 
 pub mod ty;
 
+use ty::Ty;
+
 use crate::{
 	hir::{BooleanLiteral, FloatLiteral, Identifier, IntegerLiteral, StringLiteral},
 	thir::source::Origin,
 	utils::arena::{Arena, ArenaIndex},
 };
-
-use ty::Ty;
 
 /// A mid-level IR program (MicroZinc)
 pub struct Model {

--- a/crates/shackle-compiler/src/syntax/ast/container.rs
+++ b/crates/shackle-compiler/src/syntax/ast/container.rs
@@ -1,7 +1,6 @@
 //! AST Representation for containers
 
-use super::{helpers::*, Identifier};
-use super::{AstNode, Children, Expression, Pattern};
+use super::{helpers::*, AstNode, Children, Expression, Identifier, Pattern};
 
 ast_node!(
 	/// Tuple literal
@@ -273,8 +272,9 @@ impl AssignmentGenerator {
 
 #[cfg(test)]
 mod test {
-	use crate::syntax::ast::helpers::test::*;
 	use expect_test::expect;
+
+	use crate::syntax::ast::helpers::test::*;
 
 	#[test]
 	fn test_tuple_literal() {

--- a/crates/shackle-compiler/src/syntax/ast/expression.rs
+++ b/crates/shackle-compiler/src/syntax/ast/expression.rs
@@ -2,14 +2,13 @@
 
 use std::borrow::Cow;
 
-use crate::syntax::cst::CstNode;
-
-use super::{helpers::*, Parameter, Type};
 use super::{
-	Absent, ArrayAccess, ArrayComprehension, ArrayLiteral, ArrayLiteral2D, AstNode, BooleanLiteral,
-	Children, Constraint, Declaration, FloatLiteral, Generator, Infinity, IntegerLiteral, Pattern,
-	RecordLiteral, SetComprehension, SetLiteral, StringLiteral, TupleLiteral,
+	helpers::*, Absent, ArrayAccess, ArrayComprehension, ArrayLiteral, ArrayLiteral2D, AstNode,
+	BooleanLiteral, Children, Constraint, Declaration, FloatLiteral, Generator, Infinity,
+	IntegerLiteral, Parameter, Pattern, RecordLiteral, SetComprehension, SetLiteral, StringLiteral,
+	TupleLiteral, Type,
 };
+use crate::syntax::cst::CstNode;
 
 ast_enum!(
 	/// Expression
@@ -496,8 +495,9 @@ impl Lambda {
 
 #[cfg(test)]
 mod test {
-	use crate::syntax::ast::helpers::test::*;
 	use expect_test::expect;
+
+	use crate::syntax::ast::helpers::test::*;
 
 	#[test]
 	fn test_annotated_expression() {

--- a/crates/shackle-compiler/src/syntax/ast/helpers.rs
+++ b/crates/shackle-compiler/src/syntax/ast/helpers.rs
@@ -2,9 +2,8 @@
 
 use std::marker::PhantomData;
 
-use crate::syntax::cst::CstNode;
-
 use super::{AstNode, Children};
+use crate::syntax::cst::CstNode;
 
 /// Helper to retrieve a child node by its field name
 pub fn child_with_field_name<T: AstNode, U: From<CstNode>>(parent: &T, field: &str) -> U {
@@ -263,10 +262,10 @@ pub(crate) use ast_enum;
 
 #[cfg(test)]
 pub mod test {
-	use crate::syntax::ast::Model;
-	use crate::syntax::cst::Cst;
 	use expect_test::{Expect, ExpectFile};
 	use tree_sitter::Parser;
+
+	use crate::syntax::{ast::Model, cst::Cst};
 
 	/// Helper to check parsed AST
 	pub fn check_ast(source: &str, expected: Expect) {

--- a/crates/shackle-compiler/src/syntax/ast/item.rs
+++ b/crates/shackle-compiler/src/syntax/ast/item.rs
@@ -459,8 +459,9 @@ impl TypeAlias {
 
 #[cfg(test)]
 mod test {
-	use crate::syntax::ast::helpers::test::*;
 	use expect_test::expect;
+
+	use crate::syntax::ast::helpers::test::*;
 
 	#[test]
 	fn test_include() {

--- a/crates/shackle-compiler/src/syntax/ast/mod.rs
+++ b/crates/shackle-compiler/src/syntax/ast/mod.rs
@@ -185,8 +185,9 @@ impl Debug for Model {
 
 #[cfg(test)]
 mod test {
-	use crate::syntax::ast::helpers::test::*;
 	use expect_test::{expect, expect_file};
+
+	use crate::syntax::ast::helpers::test::*;
 
 	#[test]
 	fn test_model() {

--- a/crates/shackle-compiler/src/syntax/ast/pattern.rs
+++ b/crates/shackle-compiler/src/syntax/ast/pattern.rs
@@ -117,8 +117,9 @@ impl PatternRecordField {
 
 #[cfg(test)]
 mod test {
-	use crate::syntax::ast::helpers::test::*;
 	use expect_test::expect;
+
+	use crate::syntax::ast::helpers::test::*;
 
 	#[test]
 	fn test_patterns() {

--- a/crates/shackle-compiler/src/syntax/ast/primitive.rs
+++ b/crates/shackle-compiler/src/syntax/ast/primitive.rs
@@ -1,12 +1,8 @@
 //! AST representation of primitive values
 
-use std::num::IntErrorKind;
-use std::num::ParseFloatError;
-use std::num::ParseIntError;
+use std::num::{IntErrorKind, ParseFloatError, ParseIntError};
 
-use super::AstNode;
-
-use super::helpers::*;
+use super::{helpers::*, AstNode};
 
 ast_node!(
 	/// Integer literal
@@ -227,10 +223,10 @@ pub fn parse_float_literal(text: &str) -> Result<f64, FloatParsingError> {
 
 #[cfg(test)]
 mod test {
-	use crate::syntax::ast::{helpers::test::*, FloatParsingError};
 	use expect_test::expect;
 
 	use super::parse_float_literal;
+	use crate::syntax::ast::{helpers::test::*, FloatParsingError};
 
 	#[test]
 	fn test_parse_float() {

--- a/crates/shackle-compiler/src/syntax/ast/types.rs
+++ b/crates/shackle-compiler/src/syntax/ast/types.rs
@@ -1,7 +1,6 @@
 //! AST representation for types
 
-use super::{helpers::*, Identifier};
-use super::{AstNode, Children, Expression};
+use super::{helpers::*, AstNode, Children, Expression, Identifier};
 
 ast_enum!(
 	/// Type from a declaration
@@ -329,8 +328,9 @@ impl TypeInstEnumIdentifier {
 
 #[cfg(test)]
 mod test {
-	use crate::syntax::ast::helpers::test::*;
 	use expect_test::expect;
+
+	use crate::syntax::ast::helpers::test::*;
 
 	#[test]
 	fn test_array_type() {

--- a/crates/shackle-compiler/src/syntax/cst.rs
+++ b/crates/shackle-compiler/src/syntax/cst.rs
@@ -1,17 +1,21 @@
 //! Wrappers around the tree-sitter tree to allow for usage with salsa.
 
+use std::{
+	fmt::Debug,
+	hash::{Hash, Hasher},
+	ops::Deref,
+	sync::Arc,
+};
+
 use miette::SourceSpan;
-use std::fmt::Debug;
-use std::hash::{Hash, Hasher};
-use std::ops::Deref;
-use std::sync::Arc;
 use tree_sitter::{Node, Tree, TreeCursor};
 
-use crate::db::FileReader;
-use crate::diagnostics::SyntaxError;
-use crate::file::{FileRef, SourceFile};
-
 use super::db::SourceParser;
+use crate::{
+	db::FileReader,
+	diagnostics::SyntaxError,
+	file::{FileRef, SourceFile},
+};
 
 /// Wrapper for a tree sitter tree.
 ///

--- a/crates/shackle-compiler/src/syntax/db.rs
+++ b/crates/shackle-compiler/src/syntax/db.rs
@@ -3,12 +3,12 @@
 
 use tree_sitter::Parser;
 
-use super::ast::Model;
-use super::cst::Cst;
-
-use crate::db::{FileReader, Upcast};
-use crate::file::FileRef;
-use crate::Result;
+use super::{ast::Model, cst::Cst};
+use crate::{
+	db::{FileReader, Upcast},
+	file::FileRef,
+	Result,
+};
 
 /// Syntax parsing queries
 #[salsa::query_group(SourceParserStorage)]

--- a/crates/shackle-compiler/src/thir/ir/domain.rs
+++ b/crates/shackle-compiler/src/thir/ir/domain.rs
@@ -1,16 +1,14 @@
 //! Representation of variable domains
 use std::ops::Deref;
 
+use super::{Expression, Marker};
+pub use crate::hir::{OptType, VarType};
 use crate::{
 	hir::Identifier,
 	thir::{db::Thir, source::Origin},
 	ty::{Ty, TyData},
 	utils::maybe_grow_stack,
 };
-
-use super::{Expression, Marker};
-
-pub use crate::hir::{OptType, VarType};
 
 /// Ascribed domain of a variable
 #[derive(Debug, Hash, PartialEq, Eq)]

--- a/crates/shackle-compiler/src/thir/ir/item.rs
+++ b/crates/shackle-compiler/src/thir/ir/item.rs
@@ -2,6 +2,7 @@
 
 use std::ops::{Deref, DerefMut};
 
+use super::{domain::Domain, Annotations, Expression, Identifier, Marker, Model};
 use crate::{
 	thir::{db::Thir, source::Origin},
 	ty::{
@@ -10,8 +11,6 @@ use crate::{
 	},
 	utils::{arena::ArenaIndex, impl_enum_from},
 };
-
-use super::{domain::Domain, Annotations, Expression, Identifier, Marker, Model};
 
 /// An item of type `T`.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/shackle-compiler/src/thir/ir/mod.rs
+++ b/crates/shackle-compiler/src/thir/ir/mod.rs
@@ -3,14 +3,11 @@
 
 use std::ops::Index;
 
-use crate::hir::Identifier;
-use crate::ty::FunctionEntry;
-use crate::ty::FunctionResolutionError;
-use crate::ty::OverloadedFunction;
-use crate::ty::Ty;
-use crate::ty::TyParamInstantiations;
-use crate::utils::arena::Arena;
-use crate::utils::impl_index;
+use crate::{
+	hir::Identifier,
+	ty::{FunctionEntry, FunctionResolutionError, OverloadedFunction, Ty, TyParamInstantiations},
+	utils::{arena::Arena, impl_index},
+};
 
 mod annotations;
 mod domain;
@@ -18,11 +15,7 @@ mod expression;
 mod item;
 pub mod traverse;
 
-pub use self::annotations::*;
-pub use self::domain::*;
-pub use self::expression::*;
-pub use self::item::*;
-
+pub use self::{annotations::*, domain::*, expression::*, item::*};
 use super::db::Thir;
 
 /// Entity counts

--- a/crates/shackle-compiler/src/thir/ir/traverse/mod.rs
+++ b/crates/shackle-compiler/src/thir/ir/traverse/mod.rs
@@ -7,5 +7,4 @@
 mod fold;
 mod visit;
 
-pub use self::fold::*;
-pub use self::visit::*;
+pub use self::{fold::*, visit::*};

--- a/crates/shackle-compiler/src/thir/lower.rs
+++ b/crates/shackle-compiler/src/thir/lower.rs
@@ -15,6 +15,11 @@ use std::sync::Arc;
 
 use rustc_hash::FxHashMap;
 
+use super::{
+	db::{Intermediate, Thir},
+	source::Origin,
+	*,
+};
 use crate::{
 	constants::IdentifierRegistry,
 	hir::{
@@ -24,12 +29,6 @@ use crate::{
 	},
 	ty::{OptType, Ty, TyData, VarType},
 	utils::{arena::ArenaIndex, impl_enum_from, maybe_grow_stack},
-};
-
-use super::{
-	db::{Intermediate, Thir},
-	source::Origin,
-	*,
 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/crates/shackle-compiler/src/thir/pretty_print.rs
+++ b/crates/shackle-compiler/src/thir/pretty_print.rs
@@ -1,15 +1,14 @@
 //! Pretty printing of THIR as MiniZinc
 //!
 
-use crate::utils::maybe_grow_stack;
-
-use super::db::Thir;
-use super::{
-	AnnotationId, Callable, ConstraintId, DeclarationId, Domain, DomainData, EnumerationId,
-	Expression, ExpressionData, FunctionId, Generator, Goal, ItemId, LetItem, Marker, Model,
-	OutputId, Pattern, PatternData, ResolvedIdentifier,
-};
 use std::fmt::Write;
+
+use super::{
+	db::Thir, AnnotationId, Callable, ConstraintId, DeclarationId, Domain, DomainData,
+	EnumerationId, Expression, ExpressionData, FunctionId, Generator, Goal, ItemId, LetItem,
+	Marker, Model, OutputId, Pattern, PatternData, ResolvedIdentifier,
+};
+use crate::utils::maybe_grow_stack;
 
 static MINIZINC_COMPAT: &str = include_str!("../../../../share/minizinc/compat.mzn");
 

--- a/crates/shackle-compiler/src/thir/sanity_check.rs
+++ b/crates/shackle-compiler/src/thir/sanity_check.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use super::{db::Thir, pretty_print::PrettyPrinter};
 use crate::{
 	db::{CompilerDatabase, Inputs},
 	diagnostics::Diagnostics,
@@ -10,8 +11,6 @@ use crate::{
 	hir::db::Hir,
 	Error,
 };
-
-use super::{db::Thir, pretty_print::PrettyPrinter};
 
 /// Get the diagnostics for running the pretty printed THIR.
 ///

--- a/crates/shackle-compiler/src/thir/source.rs
+++ b/crates/shackle-compiler/src/thir/source.rs
@@ -4,12 +4,11 @@
 
 use miette::SourceSpan;
 
+use super::db::Thir;
 use crate::{
 	file::SourceFile,
 	hir::ids::{EntityRef, ItemRef, NodeRef},
 };
-
-use super::db::Thir;
 
 /// The HIR node which produced a THIR node
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]

--- a/crates/shackle-compiler/src/thir/transform/call_by_name.rs
+++ b/crates/shackle-compiler/src/thir/transform/call_by_name.rs
@@ -146,10 +146,10 @@ pub fn inline_call_by_name(db: &dyn Thir, model: Model) -> Result<Model> {
 
 #[cfg(test)]
 mod test {
-	use crate::thir::transform::test::check_no_stdlib;
 	use expect_test::expect;
 
 	use super::inline_call_by_name;
+	use crate::thir::transform::test::check_no_stdlib;
 
 	#[test]
 	fn test_inline_call_by_name() {

--- a/crates/shackle-compiler/src/thir/transform/capturing_fn.rs
+++ b/crates/shackle-compiler/src/thir/transform/capturing_fn.rs
@@ -355,9 +355,8 @@ pub fn decapture_model(db: &dyn Thir, model: Model) -> Result<Model> {
 mod test {
 	use expect_test::expect;
 
-	use crate::thir::transform::test::check_no_stdlib;
-
 	use super::decapture_model;
+	use crate::thir::transform::test::check_no_stdlib;
 
 	#[test]
 	fn test_decapture() {

--- a/crates/shackle-compiler/src/thir/transform/comprehension.rs
+++ b/crates/shackle-compiler/src/thir/transform/comprehension.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use rustc_hash::FxHashMap;
 
+use super::top_down_type::add_coercion;
 use crate::{
 	constants::IdentifierRegistry,
 	hir::OptType,
@@ -21,8 +22,6 @@ use crate::{
 	utils::maybe_grow_stack,
 	Result,
 };
-
-use super::top_down_type::add_coercion;
 
 enum SurroundingCall {
 	Forall,
@@ -451,10 +450,10 @@ pub fn desugar_comprehension(db: &dyn Thir, model: Model) -> Result<Model> {
 
 #[cfg(test)]
 mod test {
-	use crate::thir::transform::test::check;
 	use expect_test::expect;
 
 	use super::desugar_comprehension;
+	use crate::thir::transform::test::check;
 
 	#[test]
 	fn test_desugar_array_comprehension_var_where() {

--- a/crates/shackle-compiler/src/thir/transform/domain_constraint.rs
+++ b/crates/shackle-compiler/src/thir/transform/domain_constraint.rs
@@ -899,10 +899,10 @@ pub fn rewrite_domains(db: &dyn Thir, model: Model) -> Result<Model> {
 
 #[cfg(test)]
 mod test {
-	use crate::thir::transform::test::check;
 	use expect_test::expect;
 
 	use super::rewrite_domains;
+	use crate::thir::transform::test::check;
 
 	#[test]
 	fn test_rewrite_struct_domains() {

--- a/crates/shackle-compiler/src/thir/transform/erase_enum.rs
+++ b/crates/shackle-compiler/src/thir/transform/erase_enum.rs
@@ -5,8 +5,11 @@
 //! Since this transform generates optional types and var set comprehensions, it must be run before
 //! option type erasure and comprehension desugaring comprehensions.
 
+use std::sync::Arc;
+
 use rustc_hash::FxHashMap;
 
+use super::top_down_type::add_coercion;
 use crate::{
 	constants::{IdentifierRegistry, TypeRegistry},
 	hir::{Identifier, IntegerLiteral, StringLiteral, VarType},
@@ -24,9 +27,6 @@ use crate::{
 	utils::{arena::ArenaMap, maybe_grow_stack},
 	Result,
 };
-use std::sync::Arc;
-
-use super::top_down_type::add_coercion;
 
 struct EnumEraser<Dst: Marker, Src: Marker = ()> {
 	model: Model<Dst>,
@@ -418,9 +418,8 @@ pub fn erase_enum(db: &dyn Thir, model: Model) -> Result<Model> {
 mod test {
 	use expect_test::expect;
 
-	use crate::thir::transform::{test::check, transformer, type_specialise::type_specialise};
-
 	use super::erase_enum;
+	use crate::thir::transform::{test::check, transformer, type_specialise::type_specialise};
 
 	#[test]
 	fn test_enum_type_erasure() {

--- a/crates/shackle-compiler/src/thir/transform/erase_opt.rs
+++ b/crates/shackle-compiler/src/thir/transform/erase_opt.rs
@@ -443,9 +443,8 @@ pub fn erase_opt(db: &dyn Thir, model: Model) -> Result<Model> {
 mod test {
 	use expect_test::expect;
 
-	use crate::thir::transform::{test::check_no_stdlib, top_down_type, transformer};
-
 	use super::erase_opt;
+	use crate::thir::transform::{test::check_no_stdlib, top_down_type, transformer};
 
 	#[test]
 	fn test_option_type_erasure() {

--- a/crates/shackle-compiler/src/thir/transform/erase_record.rs
+++ b/crates/shackle-compiler/src/thir/transform/erase_record.rs
@@ -117,9 +117,8 @@ pub fn erase_record(db: &dyn Thir, model: Model) -> Result<Model> {
 mod test {
 	use expect_test::expect;
 
-	use crate::thir::transform::test::check_no_stdlib;
-
 	use super::erase_record;
+	use crate::thir::transform::test::check_no_stdlib;
 
 	#[test]
 	fn test_record_type_erasure() {

--- a/crates/shackle-compiler/src/thir/transform/function_dispatch.rs
+++ b/crates/shackle-compiler/src/thir/transform/function_dispatch.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use super::top_down_type::add_coercion;
 use crate::{
 	constants::IdentifierRegistry,
 	hir::{Identifier, IntegerLiteral, OptType, VarType},
@@ -19,8 +20,6 @@ use crate::{
 	ty::{Ty, TyData},
 	Result,
 };
-
-use super::top_down_type::add_coercion;
 
 struct DispatchRewriter<Dst: Marker, Src: Marker = ()> {
 	model: Model<Dst>,
@@ -617,9 +616,8 @@ pub fn function_dispatch(db: &dyn Thir, model: Model) -> Result<Model> {
 mod test {
 	use expect_test::expect;
 
-	use crate::thir::transform::test::check;
-
 	use super::function_dispatch;
+	use crate::thir::transform::test::check;
 
 	#[test]
 	fn test_function_dispatch() {

--- a/crates/shackle-compiler/src/thir/transform/mod.rs
+++ b/crates/shackle-compiler/src/thir/transform/mod.rs
@@ -4,22 +4,15 @@
 //! The `crate::thir::Visitor` and `crate::thir::Folder` traits are useful for implementing these.
 //! It is the responsibility of implementors to know what constructs are expected to be present at the stage they run.
 
+use self::{
+	call_by_name::inline_call_by_name, capturing_fn::decapture_model,
+	comprehension::desugar_comprehension, domain_constraint::rewrite_domains,
+	erase_enum::erase_enum, erase_opt::erase_opt, erase_record::erase_record,
+	function_dispatch::function_dispatch, name_mangle::mangle_names, output::generate_output,
+	top_down_type::top_down_type, type_specialise::type_specialise,
+};
+use super::{db::Thir, Model};
 use crate::Result;
-
-use self::call_by_name::inline_call_by_name;
-use self::capturing_fn::decapture_model;
-use self::comprehension::desugar_comprehension;
-use self::domain_constraint::rewrite_domains;
-use self::erase_enum::erase_enum;
-use self::erase_opt::erase_opt;
-use self::erase_record::erase_record;
-use self::function_dispatch::function_dispatch;
-use self::name_mangle::mangle_names;
-use self::output::generate_output;
-use self::top_down_type::top_down_type;
-use self::type_specialise::type_specialise;
-use super::db::Thir;
-use super::Model;
 
 pub mod call_by_name;
 pub mod capturing_fn;

--- a/crates/shackle-compiler/src/thir/transform/name_mangle.rs
+++ b/crates/shackle-compiler/src/thir/transform/name_mangle.rs
@@ -42,9 +42,8 @@ pub fn mangle_names(_db: &dyn Thir, mut model: Model) -> Result<Model> {
 mod test {
 	use expect_test::expect;
 
-	use crate::thir::transform::test::check_no_stdlib;
-
 	use super::mangle_names;
+	use crate::thir::transform::test::check_no_stdlib;
 
 	#[test]
 	fn test_name_mangling() {

--- a/crates/shackle-compiler/src/thir/transform/output.rs
+++ b/crates/shackle-compiler/src/thir/transform/output.rs
@@ -115,9 +115,8 @@ pub fn generate_output(db: &dyn Thir, mut model: Model) -> Result<Model> {
 mod test {
 	use expect_test::expect;
 
-	use crate::thir::transform::test::check;
-
 	use super::generate_output;
+	use crate::thir::transform::test::check;
 
 	#[test]
 	fn test_output_generation() {

--- a/crates/shackle-compiler/src/thir/transform/top_down_type.rs
+++ b/crates/shackle-compiler/src/thir/transform/top_down_type.rs
@@ -325,9 +325,8 @@ pub fn top_down_type(db: &dyn Thir, model: Model) -> Result<Model> {
 mod test {
 	use expect_test::expect;
 
-	use crate::thir::transform::test::check_no_stdlib;
-
 	use super::top_down_type;
+	use crate::thir::transform::test::check_no_stdlib;
 
 	#[test]
 	fn test_top_down_type_bottom() {

--- a/crates/shackle-compiler/src/thir/transform/type_specialise.rs
+++ b/crates/shackle-compiler/src/thir/transform/type_specialise.rs
@@ -582,9 +582,8 @@ pub fn type_specialise(db: &dyn Thir, model: Model) -> Result<Model> {
 mod test {
 	use expect_test::expect;
 
-	use crate::thir::transform::{name_mangle::mangle_names, test::check_no_stdlib, transformer};
-
 	use super::type_specialise;
+	use crate::thir::transform::{name_mangle::mangle_names, test::check_no_stdlib, transformer};
 
 	#[test]
 	fn test_type_specialisation_basic_1() {

--- a/crates/shackle-compiler/src/ty/functions.rs
+++ b/crates/shackle-compiler/src/ty/functions.rs
@@ -1,12 +1,11 @@
 /// Function overloading and instantiation
 use rustc_hash::FxHashMap;
 
+use super::{OptType, Ty, TyData, TyVarRef, VarType};
 use crate::{
 	db::{InternedString, Interner},
 	utils::{maybe_grow_stack, DebugPrint},
 };
-
-use super::{OptType, Ty, TyData, TyVarRef, VarType};
 
 /// Represents failure to resolve overloading
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/shackle-compiler/src/ty/mod.rs
+++ b/crates/shackle-compiler/src/ty/mod.rs
@@ -10,15 +10,15 @@
 //! - Function types are never generic - since function expressions have all type-inst parameters already bound
 //!   (although the bound type-inst may itself be a type-inst variable, such as when calling a generic function from another generic function).
 
-use rustc_hash::FxHashMap;
-use std::collections::hash_map::Entry;
-use std::sync::atomic::AtomicU32;
+use std::{collections::hash_map::Entry, sync::atomic::AtomicU32};
 
-use crate::db::{InternedString, Interner};
-use crate::hir::db::Hir;
-use crate::hir::ids::PatternRef;
-use crate::hir::Identifier;
-use crate::utils::maybe_grow_stack;
+use rustc_hash::FxHashMap;
+
+use crate::{
+	db::{InternedString, Interner},
+	hir::{db::Hir, ids::PatternRef, Identifier},
+	utils::maybe_grow_stack,
+};
 
 mod functions;
 pub use self::functions::*;

--- a/crates/shackle-compiler/src/utils/mod.rs
+++ b/crates/shackle-compiler/src/utils/mod.rs
@@ -65,9 +65,11 @@ pub(crate) use impl_enum_from;
 pub(crate) use impl_index;
 use salsa::InternKey;
 
-use crate::db::InternedString;
-use crate::hir::db::Hir;
-use crate::syntax::ast::{parse_float_literal, parse_integer_literal};
+use crate::{
+	db::InternedString,
+	hir::db::Hir,
+	syntax::ast::{parse_float_literal, parse_integer_literal},
+};
 
 /// Trait for pretty printing for debugging with a Salsa database
 pub trait DebugPrint<'a> {

--- a/crates/shackle-compiler/src/utils/refmap.rs
+++ b/crates/shackle-compiler/src/utils/refmap.rs
@@ -1,8 +1,10 @@
 //! `HashMap` using pointers as keys
 
-use std::hash::{Hash, Hasher};
-use std::ops::Index;
-use std::ptr;
+use std::{
+	hash::{Hash, Hasher},
+	ops::Index,
+	ptr,
+};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 

--- a/crates/shackle-ls/src/diagnostics.rs
+++ b/crates/shackle-ls/src/diagnostics.rs
@@ -1,9 +1,11 @@
-use lsp_types::notification::Notification;
-use lsp_types::Url;
+use std::{
+	path::{Path, PathBuf},
+	str::FromStr,
+};
+
+use lsp_types::{notification::Notification, Url};
 use miette::{Diagnostic, Severity};
 use shackle_compiler::hir::db::Hir;
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 use crate::utils::span_contents_to_range;
 

--- a/crates/shackle-ls/src/handlers/completions.rs
+++ b/crates/shackle-ls/src/handlers/completions.rs
@@ -2,17 +2,18 @@ use lsp_server::ResponseError;
 use lsp_types::{
 	request::Completion, CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse,
 };
-use shackle_compiler::db::CompilerDatabase;
-use shackle_compiler::file::ModelRef;
-use shackle_compiler::hir::{
-	db::Hir,
-	source::{find_expression, Point},
-	Expression, PatternTy,
+use shackle_compiler::{
+	db::CompilerDatabase,
+	file::ModelRef,
+	hir::{
+		db::Hir,
+		source::{find_expression, Point},
+		Expression, PatternTy,
+	},
+	ty::TyData,
 };
-use shackle_compiler::ty::TyData;
 
-use crate::db::LanguageServerContext;
-use crate::dispatch::RequestHandler;
+use crate::{db::LanguageServerContext, dispatch::RequestHandler};
 
 #[derive(Debug)]
 pub struct CompletionsHandler;
@@ -210,9 +211,8 @@ mod test {
 	use expect_test::expect;
 	use lsp_types::Url;
 
-	use crate::handlers::test::test_handler;
-
 	use super::CompletionsHandler;
+	use crate::handlers::test::test_handler;
 
 	#[test]
 	fn test_completions() {

--- a/crates/shackle-ls/src/handlers/goto_definition.rs
+++ b/crates/shackle-ls/src/handlers/goto_definition.rs
@@ -5,10 +5,7 @@ use shackle_compiler::{
 	file::ModelRef,
 	hir::{
 		db::Hir,
-		ids::{NodeRef, PatternRef},
-	},
-	hir::{
-		ids::LocalEntityRef,
+		ids::{LocalEntityRef, NodeRef, PatternRef},
 		source::{find_node, Point},
 	},
 };
@@ -76,9 +73,8 @@ mod test {
 	use expect_test::expect;
 	use lsp_types::Url;
 
-	use crate::handlers::test::test_handler;
-
 	use super::GotoDefinitionHandler;
+	use crate::handlers::test::test_handler;
 
 	#[test]
 	fn test_goto_definition_1() {

--- a/crates/shackle-ls/src/handlers/hover.rs
+++ b/crates/shackle-ls/src/handlers/hover.rs
@@ -5,9 +5,9 @@ use lsp_types::{
 use shackle_compiler::{
 	db::CompilerDatabase,
 	file::ModelRef,
-	hir::{db::Hir, ids::NodeRef},
 	hir::{
-		ids::LocalEntityRef,
+		db::Hir,
+		ids::{LocalEntityRef, NodeRef},
 		source::{find_node, Point},
 	},
 };
@@ -94,9 +94,8 @@ mod test {
 	use expect_test::expect;
 	use lsp_types::Url;
 
-	use crate::handlers::test::test_handler;
-
 	use super::HoverHandler;
+	use crate::handlers::test::test_handler;
 
 	#[test]
 	fn test_hover() {

--- a/crates/shackle-ls/src/handlers/mod.rs
+++ b/crates/shackle-ls/src/handlers/mod.rs
@@ -11,34 +11,28 @@ mod view_hir;
 mod view_pretty_print;
 mod view_scope;
 
-pub use self::completions::*;
-pub use self::goto_definition::*;
-pub use self::hover::*;
-pub use self::references::*;
-pub use self::rename_symbol::*;
-pub use self::semantic_tokens::*;
-pub use self::vfs::*;
-pub use self::view_ast::*;
-pub use self::view_cst::*;
-pub use self::view_hir::*;
-pub use self::view_pretty_print::*;
-pub use self::view_scope::*;
+pub use self::{
+	completions::*, goto_definition::*, hover::*, references::*, rename_symbol::*,
+	semantic_tokens::*, vfs::*, view_ast::*, view_cst::*, view_hir::*, view_pretty_print::*,
+	view_scope::*,
+};
 
 #[cfg(test)]
 pub mod test {
-	use expect_test::Expect;
-	use lsp_server::ResponseError;
-	use shackle_compiler::{
-		db::{CompilerDatabase, FileReader, Inputs},
-		diagnostics::FileError,
-		file::{FileHandler, InputFile},
-	};
 	use std::{
 		ops::Deref,
 		panic::RefUnwindSafe,
 		path::{Path, PathBuf},
 		str::FromStr,
 		sync::Arc,
+	};
+
+	use expect_test::Expect;
+	use lsp_server::ResponseError;
+	use shackle_compiler::{
+		db::{CompilerDatabase, FileReader, Inputs},
+		diagnostics::FileError,
+		file::{FileHandler, InputFile},
 	};
 
 	use crate::{db::LanguageServerContext, dispatch::RequestHandler};

--- a/crates/shackle-ls/src/handlers/references.rs
+++ b/crates/shackle-ls/src/handlers/references.rs
@@ -3,9 +3,9 @@ use lsp_types::{request::References, Location, ReferenceParams};
 use shackle_compiler::{
 	db::CompilerDatabase,
 	file::ModelRef,
-	hir::{db::Hir, ids::NodeRef},
 	hir::{
-		ids::{LocalEntityRef, PatternRef},
+		db::Hir,
+		ids::{LocalEntityRef, NodeRef, PatternRef},
 		source::{find_node, Point},
 	},
 	syntax::db::SourceParser,
@@ -112,9 +112,8 @@ mod test {
 	use expect_test::expect;
 	use lsp_types::Url;
 
-	use crate::handlers::test::test_handler;
-
 	use super::ReferencesHandler;
+	use crate::handlers::test::test_handler;
 
 	#[test]
 	fn test_references() {

--- a/crates/shackle-ls/src/handlers/rename_symbol.rs
+++ b/crates/shackle-ls/src/handlers/rename_symbol.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use lsp_server::{ErrorCode::InvalidRequest, ResponseError};
 use lsp_types::{request::Rename, RenameParams, TextEdit, WorkspaceEdit};
 use shackle_compiler::{
@@ -11,7 +13,6 @@ use shackle_compiler::{
 	syntax::db::SourceParser,
 	utils,
 };
-use std::collections::HashMap;
 
 use crate::{db::LanguageServerContext, dispatch::RequestHandler, utils::node_ref_to_location};
 
@@ -146,9 +147,8 @@ mod test {
 	use expect_test::expect;
 	use lsp_types::{RenameParams, TextDocumentPositionParams, Url};
 
-	use crate::handlers::test::test_handler;
-
 	use super::RenameHandler;
+	use crate::handlers::test::test_handler;
 
 	#[test]
 	fn test_references() {

--- a/crates/shackle-ls/src/handlers/semantic_tokens.rs
+++ b/crates/shackle-ls/src/handlers/semantic_tokens.rs
@@ -7,9 +7,9 @@ use miette::SourceCode;
 use shackle_compiler::{
 	db::CompilerDatabase,
 	file::ModelRef,
-	hir::{db::Hir, ids::NodeRef},
 	hir::{
-		ids::{LocalEntityRef, PatternRef},
+		db::Hir,
+		ids::{LocalEntityRef, NodeRef, PatternRef},
 		PatternTy,
 	},
 	syntax::db::SourceParser,
@@ -171,9 +171,8 @@ mod test {
 	use expect_test::expect;
 	use lsp_types::Url;
 
-	use crate::handlers::test::test_handler;
-
 	use super::SemanticTokensHandler;
+	use crate::handlers::test::test_handler;
 
 	#[test]
 	fn test_semantic_tokens() {

--- a/crates/shackle-ls/src/handlers/vfs.rs
+++ b/crates/shackle-ls/src/handlers/vfs.rs
@@ -1,7 +1,8 @@
-use crate::LanguageServerDatabase;
 use lsp_types::{
 	DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
 };
+
+use crate::LanguageServerDatabase;
 
 pub fn on_document_open(db: &mut LanguageServerDatabase, params: DidOpenTextDocumentParams) {
 	let file = params

--- a/crates/shackle-ls/src/handlers/view_ast.rs
+++ b/crates/shackle-ls/src/handlers/view_ast.rs
@@ -29,9 +29,8 @@ mod test {
 	use expect_test::expect;
 	use lsp_types::Url;
 
-	use crate::handlers::test::test_handler_display;
-
 	use super::ViewAstHandler;
+	use crate::handlers::test::test_handler_display;
 
 	#[test]
 	fn test_view_ast() {

--- a/crates/shackle-ls/src/handlers/view_cst.rs
+++ b/crates/shackle-ls/src/handlers/view_cst.rs
@@ -33,9 +33,8 @@ mod test {
 	use expect_test::expect;
 	use lsp_types::Url;
 
-	use crate::handlers::test::test_handler_display;
-
 	use super::ViewCstHandler;
+	use crate::handlers::test::test_handler_display;
 
 	#[test]
 	fn test_view_cst() {

--- a/crates/shackle-ls/src/handlers/view_hir.rs
+++ b/crates/shackle-ls/src/handlers/view_hir.rs
@@ -63,9 +63,8 @@ mod test {
 	use expect_test::expect;
 	use lsp_types::Url;
 
-	use crate::handlers::test::test_handler_display;
-
 	use super::ViewHirHandler;
+	use crate::handlers::test::test_handler_display;
 
 	#[test]
 	fn test_view_hir() {

--- a/crates/shackle-ls/src/handlers/view_scope.rs
+++ b/crates/shackle-ls/src/handlers/view_scope.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write;
+
 use lsp_server::ResponseError;
 use lsp_types::TextDocumentPositionParams;
 use shackle_compiler::{
@@ -9,7 +11,6 @@ use shackle_compiler::{
 		source::{find_node, Point},
 	},
 };
-use std::fmt::Write;
 
 use crate::{db::LanguageServerContext, dispatch::RequestHandler, extensions::ViewScope};
 
@@ -76,9 +77,8 @@ mod test {
 	use expect_test::expect;
 	use lsp_types::Url;
 
-	use crate::handlers::test::test_handler_display;
-
 	use super::ViewScopeHandler;
+	use crate::handlers::test::test_handler_display;
 
 	#[test]
 	fn test_view_scope() {

--- a/crates/shackle-ls/src/main.rs
+++ b/crates/shackle-ls/src/main.rs
@@ -1,13 +1,13 @@
+use std::error::Error;
+
 use db::LanguageServerDatabase;
+use lsp_server::{Connection, ExtractError, Message};
 use lsp_types::{
 	notification::{DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument},
 	CompletionOptions, HoverProviderCapability, InitializeParams, OneOf, SemanticTokensFullOptions,
 	SemanticTokensLegend, SemanticTokensOptions, SemanticTokensServerCapabilities,
 	ServerCapabilities, TextDocumentSyncKind,
 };
-use std::error::Error;
-
-use lsp_server::{Connection, ExtractError, Message};
 
 use crate::{
 	dispatch::{DispatchNotification, DispatchRequest},

--- a/crates/shackle/src/data/dzn.rs
+++ b/crates/shackle/src/data/dzn.rs
@@ -6,14 +6,6 @@
 use std::sync::Arc;
 
 use itertools::Itertools;
-use tree_sitter::Parser;
-
-use crate::{
-	data::ParserVal,
-	value::{EnumInner, Index, Polarity, Set},
-	Enum, OptType, Type, Value,
-};
-
 use shackle_compiler::{
 	diagnostics::{Error, InvalidArrayLiteral, InvalidNumericLiteral, SyntaxError, TypeMismatch},
 	file::SourceFile,
@@ -24,6 +16,13 @@ use shackle_compiler::{
 		},
 		cst::{Cst, CstNode},
 	},
+};
+use tree_sitter::Parser;
+
+use crate::{
+	data::ParserVal,
+	value::{EnumInner, Index, Polarity, Set},
+	Enum, OptType, Type, Value,
 };
 
 /// Parses a DataZinc file, returning a mapping of the name of the left hand

--- a/crates/shackle/src/lib.rs
+++ b/crates/shackle/src/lib.rs
@@ -8,23 +8,6 @@ mod data;
 mod legacy;
 mod value;
 
-use data::{
-	dzn::{collect_dzn_value, parse_dzn},
-	serde::SerdeFileVisitor,
-};
-use itertools::Itertools;
-use rustc_hash::{FxHashMap, FxHashSet};
-use serde::Deserializer;
-use shackle_compiler::file::{InputFile, SourceFile};
-use shackle_compiler::syntax::ast::{AstNode, Identifier};
-use shackle_compiler::thir;
-use shackle_compiler::ty::{Ty, TyData};
-use shackle_compiler::{
-	db::{CompilerDatabase, Inputs, InternedString, Interner},
-	thir::Declaration,
-};
-use value::EnumInner;
-
 use std::{
 	ffi::OsStr,
 	fmt::Display,
@@ -35,19 +18,31 @@ use std::{
 	time::Duration,
 };
 
-use shackle_compiler::hir::db::Hir;
-use shackle_compiler::thir::{db::Thir, pretty_print::PrettyPrinter};
-// Export OptType enumeration used in [`Type`]
-pub use shackle_compiler::ty::OptType;
-
+use data::{
+	dzn::{collect_dzn_value, parse_dzn},
+	serde::SerdeFileVisitor,
+};
 /// Result type for Shackle operations
 pub use error::{Error, Result};
+use itertools::Itertools;
+use rustc_hash::{FxHashMap, FxHashSet};
+use serde::Deserializer;
+// Export OptType enumeration used in [`Type`]
+pub use shackle_compiler::ty::OptType;
+use shackle_compiler::{
+	db::{CompilerDatabase, Inputs, InternedString, Interner},
+	file::{InputFile, SourceFile},
+	hir::db::Hir,
+	syntax::ast::{AstNode, Identifier},
+	thir::{self, db::Thir, pretty_print::PrettyPrinter, Declaration},
+	ty::{Ty, TyData},
+};
+use value::EnumInner;
 pub use value::{Enum, Value};
 
 /// Shackle errors
 pub mod error {
-	pub use shackle_compiler::diagnostics::error::*;
-	pub use shackle_compiler::Result;
+	pub use shackle_compiler::{diagnostics::error::*, Result};
 }
 
 /// Shackle warnings

--- a/crates/shackle/src/lib.rs
+++ b/crates/shackle/src/lib.rs
@@ -1,4 +1,4 @@
-//! Shackle library
+//! Shackle user-facing library.
 
 #![warn(missing_docs)]
 #![warn(unused_crate_dependencies, unused_extern_crates)]
@@ -22,7 +22,7 @@ use data::{
 	dzn::{collect_dzn_value, parse_dzn},
 	serde::SerdeFileVisitor,
 };
-/// Result type for Shackle operations
+// Result type for Shackle operations
 pub use error::{Error, Result};
 use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -47,9 +47,9 @@ pub mod error {
 
 /// Shackle warnings
 pub mod warning {
-
 	pub use shackle_compiler::diagnostics::warning::*;
 }
+
 /// Structure used to build a shackle model
 pub struct Model {
 	db: CompilerDatabase,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,3 @@
 hard_tabs = true
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
Consistent formatting of `use` statements is currently only available in nightly `rustfmt`.

So `cargo +nightly fmt` is needed, and for rust-analyzer, use `"rust-analyzer.rustfmt.extraArgs": ["+nightly"]`.