### PR TITLE
Fix clippy::map_identity lint warning.

### DIFF
--- a/crates/shackle-compiler/src/hir/typecheck/mod.rs
+++ b/crates/shackle-compiler/src/hir/typecheck/mod.rs
@@ -262,7 +262,6 @@ impl<'a> DebugPrint<'a> for TypeResult {
 			.body
 			.patterns
 			.iter()
-			.map(|(p, d)| (p, d))
 			.chain(self.signature.iter().flat_map(|ts| {
 				ts.patterns.iter().filter_map(|(p, d)| {
 					if p.item() == self.item {


### PR DESCRIPTION
This map isn't needed here and should be able to be safely removed.