### PR TITLE
tree-sitter-datazinc: Update edition to 2021.

### DIFF
--- a/parsers/tree-sitter-datazinc/Cargo.toml
+++ b/parsers/tree-sitter-datazinc/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 keywords = ["incremental", "parsing", "datazinc"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/tree-sitter/tree-sitter-datazinc"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 build = "bindings/rust/build.rs"


### PR DESCRIPTION
All other crates in this repo are 2021, so update this to match.