### PR TITLE
Add FlatZinc serialization crate

### DIFF
--- a/crates/flatzinc-serde/Cargo.toml
+++ b/crates/flatzinc-serde/Cargo.toml
@@ -2,7 +2,10 @@
 name = "flatzinc-serde"
 version = "0.1.0"
 description = "FlatZinc serialization and deserialization"
-authors = ["Jip J. Dekker <jip@dekker.one>"]
+authors = [
+    "Jip J. Dekker <jip@dekker.one>",
+    "Jason Nguyen <admin@cyderize.org>",
+]
 
 homepage = "https://www.minizinc.org/"
 repository = "https://github.com/shackle-rs/shackle/"

--- a/crates/flatzinc-serde/Cargo.toml
+++ b/crates/flatzinc-serde/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "flatzinc-serde"
 version = "0.1.0"
+description = "FlatZinc serialization and deserialization"
 authors = ["Jip J. Dekker <jip@dekker.one>"]
+
+homepage = "https://www.minizinc.org/"
+repository = "https://github.com/shackle-rs/shackle/"
 license = "MPL-2.0"
+keywords = ["minizinc", "flatzinc", "serde", "optimization", "serialization"]
+exclude = ["/corpus"]
 
 edition = "2021"
 

--- a/crates/flatzinc-serde/Cargo.toml
+++ b/crates/flatzinc-serde/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "flatzinc-serde"
+version = "0.1.0"
+authors = ["Jip J. Dekker <jip@dekker.one>"]
+license = "MPL-2.0"
+
+edition = "2021"
+
+[dependencies]

--- a/crates/flatzinc-serde/Cargo.toml
+++ b/crates/flatzinc-serde/Cargo.toml
@@ -7,3 +7,8 @@ license = "MPL-2.0"
 edition = "2021"
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1.0"
+expect-test = "1.4"

--- a/crates/flatzinc-serde/corpus/documentation_example.debug.txt
+++ b/crates/flatzinc-serde/corpus/documentation_example.debug.txt
@@ -185,7 +185,7 @@ FlatZinc {
             ),
             introduced: false,
             value: None,
-            ty: "int",
+            ty: Int,
         },
         "b": Variable {
             ann: [],
@@ -197,7 +197,7 @@ FlatZinc {
             ),
             introduced: false,
             value: None,
-            ty: "int",
+            ty: Int,
         },
         "c": Variable {
             ann: [],
@@ -209,7 +209,7 @@ FlatZinc {
             ),
             introduced: false,
             value: None,
-            ty: "int",
+            ty: Int,
         },
     },
     version: "",

--- a/crates/flatzinc-serde/corpus/documentation_example.debug.txt
+++ b/crates/flatzinc-serde/corpus/documentation_example.debug.txt
@@ -1,4 +1,42 @@
 FlatZinc {
+    variables: {
+        "X_INTRODUCED_0_": Variable {
+            ty: Int,
+            domain: Some(
+                Int(
+                    RangeList::from_iter([0..=85000]),
+                ),
+            ),
+            value: None,
+            ann: [],
+            defined: true,
+            introduced: false,
+        },
+        "b": Variable {
+            ty: Int,
+            domain: Some(
+                Int(
+                    RangeList::from_iter([0..=3]),
+                ),
+            ),
+            value: None,
+            ann: [],
+            defined: false,
+            introduced: false,
+        },
+        "c": Variable {
+            ty: Int,
+            domain: Some(
+                Int(
+                    RangeList::from_iter([0..=6]),
+                ),
+            ),
+            value: None,
+            ann: [],
+            defined: false,
+            introduced: false,
+        },
+    },
     arrays: {
         "X_INTRODUCED_2_": Array {
             contents: [
@@ -42,7 +80,7 @@ FlatZinc {
     },
     constraints: [
         Call {
-            ann: [],
+            id: "int_lin_le",
             args: [
                 Literal(
                     Identifier(
@@ -65,10 +103,10 @@ FlatZinc {
                     ),
                 ),
             ],
-            id: "int_lin_le",
+            ann: [],
         },
         Call {
-            ann: [],
+            id: "int_lin_le",
             args: [
                 Literal(
                     Identifier(
@@ -91,10 +129,10 @@ FlatZinc {
                     ),
                 ),
             ],
-            id: "int_lin_le",
+            ann: [],
         },
         Call {
-            ann: [],
+            id: "int_lin_le",
             args: [
                 Literal(
                     Identifier(
@@ -117,14 +155,10 @@ FlatZinc {
                     ),
                 ),
             ],
-            id: "int_lin_le",
+            ann: [],
         },
         Call {
-            ann: [
-                Atom(
-                    "ctx_pos",
-                ),
-            ],
+            id: "int_lin_eq",
             args: [
                 Array(
                     [
@@ -158,7 +192,11 @@ FlatZinc {
                     ),
                 ),
             ],
-            id: "int_lin_eq",
+            ann: [
+                Atom(
+                    "ctx_pos",
+                ),
+            ],
         },
     ],
     output: [
@@ -166,51 +204,13 @@ FlatZinc {
         "c",
     ],
     solve: SolveObjective {
-        ann: [],
         method: Maximize,
         objective: Some(
             Identifier(
                 "X_INTRODUCED_0_",
             ),
         ),
-    },
-    variables: {
-        "X_INTRODUCED_0_": Variable {
-            ann: [],
-            defined: true,
-            domain: Some(
-                Int(
-                    RangeList::from_iter([0..=85000]),
-                ),
-            ),
-            introduced: false,
-            value: None,
-            ty: Int,
-        },
-        "b": Variable {
-            ann: [],
-            defined: false,
-            domain: Some(
-                Int(
-                    RangeList::from_iter([0..=3]),
-                ),
-            ),
-            introduced: false,
-            value: None,
-            ty: Int,
-        },
-        "c": Variable {
-            ann: [],
-            defined: false,
-            domain: Some(
-                Int(
-                    RangeList::from_iter([0..=6]),
-                ),
-            ),
-            introduced: false,
-            value: None,
-            ty: Int,
-        },
+        ann: [],
     },
     version: "",
 }

--- a/crates/flatzinc-serde/corpus/documentation_example.debug.txt
+++ b/crates/flatzinc-serde/corpus/documentation_example.debug.txt
@@ -179,7 +179,9 @@ FlatZinc {
             ann: [],
             defined: true,
             domain: Some(
-                RangeList::from_iter([0..=85000]),
+                Int(
+                    RangeList::from_iter([0..=85000]),
+                ),
             ),
             introduced: false,
             value: None,
@@ -189,7 +191,9 @@ FlatZinc {
             ann: [],
             defined: false,
             domain: Some(
-                RangeList::from_iter([0..=3]),
+                Int(
+                    RangeList::from_iter([0..=3]),
+                ),
             ),
             introduced: false,
             value: None,
@@ -199,7 +203,9 @@ FlatZinc {
             ann: [],
             defined: false,
             domain: Some(
-                RangeList::from_iter([0..=6]),
+                Int(
+                    RangeList::from_iter([0..=6]),
+                ),
             ),
             introduced: false,
             value: None,

--- a/crates/flatzinc-serde/corpus/documentation_example.debug.txt
+++ b/crates/flatzinc-serde/corpus/documentation_example.debug.txt
@@ -1,0 +1,225 @@
+FlatZinc {
+    arrays: {
+        "X_INTRODUCED_2_": Array {
+            contents: [
+                Int(
+                    250,
+                ),
+                Int(
+                    200,
+                ),
+            ],
+            ann: [],
+            defined: false,
+            introduced: false,
+        },
+        "X_INTRODUCED_6_": Array {
+            contents: [
+                Int(
+                    75,
+                ),
+                Int(
+                    150,
+                ),
+            ],
+            ann: [],
+            defined: false,
+            introduced: false,
+        },
+        "X_INTRODUCED_8_": Array {
+            contents: [
+                Int(
+                    100,
+                ),
+                Int(
+                    150,
+                ),
+            ],
+            ann: [],
+            defined: false,
+            introduced: false,
+        },
+    },
+    constraints: [
+        Call {
+            ann: [],
+            args: [
+                Literal(
+                    Identifier(
+                        "X_INTRODUCED_2_",
+                    ),
+                ),
+                Array(
+                    [
+                        Identifier(
+                            "b",
+                        ),
+                        Identifier(
+                            "c",
+                        ),
+                    ],
+                ),
+                Literal(
+                    Int(
+                        4000,
+                    ),
+                ),
+            ],
+            id: "int_lin_le",
+        },
+        Call {
+            ann: [],
+            args: [
+                Literal(
+                    Identifier(
+                        "X_INTRODUCED_6_",
+                    ),
+                ),
+                Array(
+                    [
+                        Identifier(
+                            "b",
+                        ),
+                        Identifier(
+                            "c",
+                        ),
+                    ],
+                ),
+                Literal(
+                    Int(
+                        2000,
+                    ),
+                ),
+            ],
+            id: "int_lin_le",
+        },
+        Call {
+            ann: [],
+            args: [
+                Literal(
+                    Identifier(
+                        "X_INTRODUCED_8_",
+                    ),
+                ),
+                Array(
+                    [
+                        Identifier(
+                            "b",
+                        ),
+                        Identifier(
+                            "c",
+                        ),
+                    ],
+                ),
+                Literal(
+                    Int(
+                        500,
+                    ),
+                ),
+            ],
+            id: "int_lin_le",
+        },
+        Call {
+            ann: [
+                Atom(
+                    "ctx_pos",
+                ),
+            ],
+            args: [
+                Array(
+                    [
+                        Int(
+                            400,
+                        ),
+                        Int(
+                            450,
+                        ),
+                        Int(
+                            -1,
+                        ),
+                    ],
+                ),
+                Array(
+                    [
+                        Identifier(
+                            "b",
+                        ),
+                        Identifier(
+                            "c",
+                        ),
+                        Identifier(
+                            "X_INTRODUCED_0_",
+                        ),
+                    ],
+                ),
+                Literal(
+                    Int(
+                        0,
+                    ),
+                ),
+            ],
+            id: "int_lin_eq",
+        },
+    ],
+    output: [
+        "b",
+        "c",
+    ],
+    solve: SolveObjective {
+        ann: [],
+        method: Maximize,
+        objective: Some(
+            Identifier(
+                "X_INTRODUCED_0_",
+            ),
+        ),
+    },
+    variables: {
+        "X_INTRODUCED_0_": Variable {
+            ann: [],
+            defined: true,
+            domain: Some(
+                [
+                    [
+                        0,
+                        85000,
+                    ],
+                ],
+            ),
+            introduced: false,
+            value: None,
+            ty: "int",
+        },
+        "b": Variable {
+            ann: [],
+            defined: false,
+            domain: Some(
+                [
+                    [
+                        0,
+                        3,
+                    ],
+                ],
+            ),
+            introduced: false,
+            value: None,
+            ty: "int",
+        },
+        "c": Variable {
+            ann: [],
+            defined: false,
+            domain: Some(
+                [
+                    [
+                        0,
+                        6,
+                    ],
+                ],
+            ),
+            introduced: false,
+            value: None,
+            ty: "int",
+        },
+    },
+    version: "",
+}

--- a/crates/flatzinc-serde/corpus/documentation_example.debug.txt
+++ b/crates/flatzinc-serde/corpus/documentation_example.debug.txt
@@ -179,12 +179,7 @@ FlatZinc {
             ann: [],
             defined: true,
             domain: Some(
-                [
-                    [
-                        0,
-                        85000,
-                    ],
-                ],
+                RangeList::from_iter([0..=85000]),
             ),
             introduced: false,
             value: None,
@@ -194,12 +189,7 @@ FlatZinc {
             ann: [],
             defined: false,
             domain: Some(
-                [
-                    [
-                        0,
-                        3,
-                    ],
-                ],
+                RangeList::from_iter([0..=3]),
             ),
             introduced: false,
             value: None,
@@ -209,12 +199,7 @@ FlatZinc {
             ann: [],
             defined: false,
             domain: Some(
-                [
-                    [
-                        0,
-                        6,
-                    ],
-                ],
+                RangeList::from_iter([0..=6]),
             ),
             introduced: false,
             value: None,

--- a/crates/flatzinc-serde/corpus/documentation_example.fzn.json
+++ b/crates/flatzinc-serde/corpus/documentation_example.fzn.json
@@ -1,0 +1,30 @@
+{
+	"variables": {
+		"b": { "type": "int", "domain": [[0, 3]] },
+		"c": { "type": "int", "domain": [[0, 6]] },
+		"X_INTRODUCED_0_": {
+			"type": "int",
+			"domain": [[0, 85000]],
+			"defined": true
+		}
+	},
+	"arrays": {
+		"X_INTRODUCED_2_": { "a": [250, 200] },
+		"X_INTRODUCED_6_": { "a": [75, 150] },
+		"X_INTRODUCED_8_": { "a": [100, 150] }
+	},
+	"constraints": [
+		{ "id": "int_lin_le", "args": ["X_INTRODUCED_2_", ["b", "c"], 4000] },
+		{ "id": "int_lin_le", "args": ["X_INTRODUCED_6_", ["b", "c"], 2000] },
+		{ "id": "int_lin_le", "args": ["X_INTRODUCED_8_", ["b", "c"], 500] },
+		{
+			"id": "int_lin_eq",
+			"args": [[400, 450, -1], ["b", "c", "X_INTRODUCED_0_"], 0],
+			"ann": ["ctx_pos"],
+			"defines": "X_INTRODUCED_0_"
+		}
+	],
+	"output": ["b", "c"],
+	"solve": { "method": "maximize", "objective": "X_INTRODUCED_0_" },
+	"verson": "1.0"
+}

--- a/crates/flatzinc-serde/corpus/encapsulated_string.debug.txt
+++ b/crates/flatzinc-serde/corpus/encapsulated_string.debug.txt
@@ -1,0 +1,26 @@
+FlatZinc {
+    arrays: {},
+    constraints: [],
+    output: [],
+    solve: SolveObjective {
+        ann: [
+            Call(
+                Call {
+                    ann: [],
+                    args: [
+                        Literal(
+                            String(
+                                "my string",
+                            ),
+                        ),
+                    ],
+                    id: "myAnn",
+                },
+            ),
+        ],
+        method: Satisfy,
+        objective: None,
+    },
+    variables: {},
+    version: "",
+}

--- a/crates/flatzinc-serde/corpus/encapsulated_string.debug.txt
+++ b/crates/flatzinc-serde/corpus/encapsulated_string.debug.txt
@@ -1,12 +1,15 @@
 FlatZinc {
+    variables: {},
     arrays: {},
     constraints: [],
     output: [],
     solve: SolveObjective {
+        method: Satisfy,
+        objective: None,
         ann: [
             Call(
                 Call {
-                    ann: [],
+                    id: "myAnn",
                     args: [
                         Literal(
                             String(
@@ -14,13 +17,10 @@ FlatZinc {
                             ),
                         ),
                     ],
-                    id: "myAnn",
+                    ann: [],
                 },
             ),
         ],
-        method: Satisfy,
-        objective: None,
     },
-    variables: {},
     version: "",
 }

--- a/crates/flatzinc-serde/corpus/encapsulated_string.fzn.json
+++ b/crates/flatzinc-serde/corpus/encapsulated_string.fzn.json
@@ -1,0 +1,20 @@
+{
+	"variables": {},
+	"arrays": {},
+	"constraints": [],
+	"output": [],
+	"solve": {
+		"method": "satisfy",
+		"ann": [
+			{
+				"id": "myAnn",
+				"args": [
+					{
+						"string": "my string"
+					}
+				]
+			}
+		]
+	},
+	"verson": "1.0"
+}

--- a/crates/flatzinc-serde/corpus/float_sets.debug.txt
+++ b/crates/flatzinc-serde/corpus/float_sets.debug.txt
@@ -1,0 +1,87 @@
+FlatZinc {
+    arrays: {},
+    constraints: [
+        Call {
+            ann: [],
+            args: [
+                Literal(
+                    Identifier(
+                        "x",
+                    ),
+                ),
+                Literal(
+                    FloatSet(
+                        RangeList::from_iter([1.5..=3.2, 5.4..=5.4, 10.3..=10.3]),
+                    ),
+                ),
+            ],
+            id: "my_float_in",
+        },
+        Call {
+            ann: [],
+            args: [
+                Literal(
+                    Identifier(
+                        "a",
+                    ),
+                ),
+                Literal(
+                    IntSet(
+                        RangeList::from_iter([1..=12, 14..=14, 19..=19]),
+                    ),
+                ),
+                Literal(
+                    Identifier(
+                        "c",
+                    ),
+                ),
+            ],
+            id: "set_in_reif",
+        },
+    ],
+    output: [
+        "x",
+        "a",
+        "c",
+    ],
+    solve: SolveObjective {
+        ann: [],
+        method: Satisfy,
+        objective: None,
+    },
+    variables: {
+        "a": Variable {
+            ann: [],
+            defined: false,
+            domain: Some(
+                Int(
+                    RangeList::from_iter([1..=100]),
+                ),
+            ),
+            introduced: false,
+            value: None,
+            ty: "int",
+        },
+        "c": Variable {
+            ann: [],
+            defined: true,
+            domain: None,
+            introduced: false,
+            value: None,
+            ty: "bool",
+        },
+        "x": Variable {
+            ann: [],
+            defined: false,
+            domain: Some(
+                Float(
+                    RangeList::from_iter([1.0..=100.0]),
+                ),
+            ),
+            introduced: false,
+            value: None,
+            ty: "float",
+        },
+    },
+    version: "",
+}

--- a/crates/flatzinc-serde/corpus/float_sets.debug.txt
+++ b/crates/flatzinc-serde/corpus/float_sets.debug.txt
@@ -1,8 +1,42 @@
 FlatZinc {
+    variables: {
+        "a": Variable {
+            ty: Int,
+            domain: Some(
+                Int(
+                    RangeList::from_iter([1..=100]),
+                ),
+            ),
+            value: None,
+            ann: [],
+            defined: false,
+            introduced: false,
+        },
+        "c": Variable {
+            ty: Bool,
+            domain: None,
+            value: None,
+            ann: [],
+            defined: true,
+            introduced: false,
+        },
+        "x": Variable {
+            ty: Float,
+            domain: Some(
+                Float(
+                    RangeList::from_iter([1.0..=100.0]),
+                ),
+            ),
+            value: None,
+            ann: [],
+            defined: false,
+            introduced: false,
+        },
+    },
     arrays: {},
     constraints: [
         Call {
-            ann: [],
+            id: "my_float_in",
             args: [
                 Literal(
                     Identifier(
@@ -15,10 +49,10 @@ FlatZinc {
                     ),
                 ),
             ],
-            id: "my_float_in",
+            ann: [],
         },
         Call {
-            ann: [],
+            id: "set_in_reif",
             args: [
                 Literal(
                     Identifier(
@@ -36,7 +70,7 @@ FlatZinc {
                     ),
                 ),
             ],
-            id: "set_in_reif",
+            ann: [],
         },
     ],
     output: [
@@ -45,43 +79,9 @@ FlatZinc {
         "c",
     ],
     solve: SolveObjective {
-        ann: [],
         method: Satisfy,
         objective: None,
-    },
-    variables: {
-        "a": Variable {
-            ann: [],
-            defined: false,
-            domain: Some(
-                Int(
-                    RangeList::from_iter([1..=100]),
-                ),
-            ),
-            introduced: false,
-            value: None,
-            ty: Int,
-        },
-        "c": Variable {
-            ann: [],
-            defined: true,
-            domain: None,
-            introduced: false,
-            value: None,
-            ty: Bool,
-        },
-        "x": Variable {
-            ann: [],
-            defined: false,
-            domain: Some(
-                Float(
-                    RangeList::from_iter([1.0..=100.0]),
-                ),
-            ),
-            introduced: false,
-            value: None,
-            ty: Float,
-        },
+        ann: [],
     },
     version: "",
 }

--- a/crates/flatzinc-serde/corpus/float_sets.debug.txt
+++ b/crates/flatzinc-serde/corpus/float_sets.debug.txt
@@ -60,7 +60,7 @@ FlatZinc {
             ),
             introduced: false,
             value: None,
-            ty: "int",
+            ty: Int,
         },
         "c": Variable {
             ann: [],
@@ -68,7 +68,7 @@ FlatZinc {
             domain: None,
             introduced: false,
             value: None,
-            ty: "bool",
+            ty: Bool,
         },
         "x": Variable {
             ann: [],
@@ -80,7 +80,7 @@ FlatZinc {
             ),
             introduced: false,
             value: None,
-            ty: "float",
+            ty: Float,
         },
     },
     version: "",

--- a/crates/flatzinc-serde/corpus/float_sets.fzn.json
+++ b/crates/flatzinc-serde/corpus/float_sets.fzn.json
@@ -1,0 +1,40 @@
+{
+	"variables": {
+		"x": { "type": "float", "domain": [[1.0, 100.0]] },
+		"a": { "type": "int", "domain": [[1, 100]] },
+		"c": { "type": "bool", "defined": true }
+	},
+	"arrays": {},
+	"constraints": [
+		{
+			"id": "my_float_in",
+			"args": [
+				"x",
+				{
+					"set": [
+						[1.5, 3.2],
+						[5.4, 5.4],
+						[10.3, 10.3]
+					]
+				}
+			]
+		},
+		{
+			"id": "set_in_reif",
+			"args": [
+				"a",
+				{
+					"set": [
+						[1, 12],
+						[14, 14],
+						[19, 19]
+					]
+				},
+				"c"
+			],
+			"defines": "c"
+		}
+	],
+	"output": ["x", "a", "c"],
+	"solve": { "method": "satisfy" }
+}

--- a/crates/flatzinc-serde/corpus/set_literals.debug.txt
+++ b/crates/flatzinc-serde/corpus/set_literals.debug.txt
@@ -1,0 +1,96 @@
+FlatZinc {
+    arrays: {
+        "X_INTRODUCED_3_": Array {
+            contents: [
+                Set(
+                    SetLiteral {
+                        set: RangeList::from_iter([2.0..=3.0]),
+                    },
+                ),
+                Set(
+                    SetLiteral {
+                        set: RangeList::from_iter([1.0..=1.0, 3.0..=3.0]),
+                    },
+                ),
+                Set(
+                    SetLiteral {
+                        set: RangeList::from_iter([1.0..=2.0]),
+                    },
+                ),
+            ],
+            ann: [],
+            defined: false,
+            introduced: false,
+        },
+    },
+    constraints: [
+        Call {
+            ann: [],
+            args: [
+                Literal(
+                    Identifier(
+                        "i",
+                    ),
+                ),
+                Literal(
+                    Identifier(
+                        "X_INTRODUCED_3_",
+                    ),
+                ),
+                Literal(
+                    Identifier(
+                        "X_INTRODUCED_0_",
+                    ),
+                ),
+            ],
+            id: "array_set_element",
+        },
+        Call {
+            ann: [],
+            args: [
+                Literal(
+                    Identifier(
+                        "i",
+                    ),
+                ),
+                Literal(
+                    Identifier(
+                        "X_INTRODUCED_0_",
+                    ),
+                ),
+            ],
+            id: "set_in",
+        },
+    ],
+    output: [
+        "i",
+    ],
+    solve: SolveObjective {
+        ann: [],
+        method: Satisfy,
+        objective: None,
+    },
+    variables: {
+        "X_INTRODUCED_0_": Variable {
+            ann: [],
+            defined: true,
+            domain: Some(
+                RangeList::from_iter([1..=3]),
+            ),
+            introduced: true,
+            value: None,
+            ty: "set of int",
+        },
+        "i": Variable {
+            ann: [],
+            defined: false,
+            domain: Some(
+                RangeList::from_iter([1..=3]),
+            ),
+            introduced: false,
+            value: None,
+            ty: "int",
+        },
+    },
+    version: "",
+}

--- a/crates/flatzinc-serde/corpus/set_literals.debug.txt
+++ b/crates/flatzinc-serde/corpus/set_literals.debug.txt
@@ -1,4 +1,30 @@
 FlatZinc {
+    variables: {
+        "X_INTRODUCED_0_": Variable {
+            ty: IntSet,
+            domain: Some(
+                Int(
+                    RangeList::from_iter([1..=3]),
+                ),
+            ),
+            value: None,
+            ann: [],
+            defined: true,
+            introduced: true,
+        },
+        "i": Variable {
+            ty: Int,
+            domain: Some(
+                Int(
+                    RangeList::from_iter([1..=3]),
+                ),
+            ),
+            value: None,
+            ann: [],
+            defined: false,
+            introduced: false,
+        },
+    },
     arrays: {
         "X_INTRODUCED_3_": Array {
             contents: [
@@ -19,7 +45,7 @@ FlatZinc {
     },
     constraints: [
         Call {
-            ann: [],
+            id: "array_set_element",
             args: [
                 Literal(
                     Identifier(
@@ -37,10 +63,10 @@ FlatZinc {
                     ),
                 ),
             ],
-            id: "array_set_element",
+            ann: [],
         },
         Call {
-            ann: [],
+            id: "set_in",
             args: [
                 Literal(
                     Identifier(
@@ -53,42 +79,16 @@ FlatZinc {
                     ),
                 ),
             ],
-            id: "set_in",
+            ann: [],
         },
     ],
     output: [
         "i",
     ],
     solve: SolveObjective {
-        ann: [],
         method: Satisfy,
         objective: None,
-    },
-    variables: {
-        "X_INTRODUCED_0_": Variable {
-            ann: [],
-            defined: true,
-            domain: Some(
-                Int(
-                    RangeList::from_iter([1..=3]),
-                ),
-            ),
-            introduced: true,
-            value: None,
-            ty: IntSet,
-        },
-        "i": Variable {
-            ann: [],
-            defined: false,
-            domain: Some(
-                Int(
-                    RangeList::from_iter([1..=3]),
-                ),
-            ),
-            introduced: false,
-            value: None,
-            ty: Int,
-        },
+        ann: [],
     },
     version: "",
 }

--- a/crates/flatzinc-serde/corpus/set_literals.debug.txt
+++ b/crates/flatzinc-serde/corpus/set_literals.debug.txt
@@ -75,7 +75,7 @@ FlatZinc {
             ),
             introduced: true,
             value: None,
-            ty: "set of int",
+            ty: IntSet,
         },
         "i": Variable {
             ann: [],
@@ -87,7 +87,7 @@ FlatZinc {
             ),
             introduced: false,
             value: None,
-            ty: "int",
+            ty: Int,
         },
     },
     version: "",

--- a/crates/flatzinc-serde/corpus/set_literals.debug.txt
+++ b/crates/flatzinc-serde/corpus/set_literals.debug.txt
@@ -2,20 +2,14 @@ FlatZinc {
     arrays: {
         "X_INTRODUCED_3_": Array {
             contents: [
-                Set(
-                    SetLiteral {
-                        set: RangeList::from_iter([2.0..=3.0]),
-                    },
+                IntSet(
+                    RangeList::from_iter([2..=3]),
                 ),
-                Set(
-                    SetLiteral {
-                        set: RangeList::from_iter([1.0..=1.0, 3.0..=3.0]),
-                    },
+                IntSet(
+                    RangeList::from_iter([1..=1, 3..=3]),
                 ),
-                Set(
-                    SetLiteral {
-                        set: RangeList::from_iter([1.0..=2.0]),
-                    },
+                IntSet(
+                    RangeList::from_iter([1..=2]),
                 ),
             ],
             ann: [],
@@ -75,7 +69,9 @@ FlatZinc {
             ann: [],
             defined: true,
             domain: Some(
-                RangeList::from_iter([1..=3]),
+                Int(
+                    RangeList::from_iter([1..=3]),
+                ),
             ),
             introduced: true,
             value: None,
@@ -85,7 +81,9 @@ FlatZinc {
             ann: [],
             defined: false,
             domain: Some(
-                RangeList::from_iter([1..=3]),
+                Int(
+                    RangeList::from_iter([1..=3]),
+                ),
             ),
             introduced: false,
             value: None,

--- a/crates/flatzinc-serde/corpus/set_literals.fzn.json
+++ b/crates/flatzinc-serde/corpus/set_literals.fzn.json
@@ -1,0 +1,35 @@
+{
+	"variables": {
+		"i": { "type": "int", "domain": [[1, 3]] },
+		"X_INTRODUCED_0_": {
+			"type": "set of int",
+			"domain": [[1, 3]],
+			"introduced": true,
+			"defined": true
+		}
+	},
+	"arrays": {
+		"X_INTRODUCED_3_": {
+			"a": [
+				{ "set": [[2, 3]] },
+				{
+					"set": [
+						[1, 1],
+						[3, 3]
+					]
+				},
+				{ "set": [[1, 2]] }
+			]
+		}
+	},
+	"constraints": [
+		{
+			"id": "array_set_element",
+			"args": ["i", "X_INTRODUCED_3_", "X_INTRODUCED_0_"],
+			"defines": "X_INTRODUCED_0_"
+		},
+		{ "id": "set_in", "args": ["i", "X_INTRODUCED_0_"] }
+	],
+	"output": ["i"],
+	"solve": { "method": "satisfy" }
+}

--- a/crates/flatzinc-serde/src/encapsulate.rs
+++ b/crates/flatzinc-serde/src/encapsulate.rs
@@ -8,7 +8,7 @@ use crate::RangeList;
 struct StringLiteral {
 	string: String,
 }
-/// Deserialisation function to resolve the encapsulation of string literals in
+/// Deserialization function to resolve the encapsulation of string literals in
 /// the FlatZinc serialization format
 pub fn deserialize_encapsulated_string<'de, D: Deserializer<'de>>(
 	deserializer: D,
@@ -37,7 +37,7 @@ pub fn serialize_encapsulate_string<S: Serializer>(
 struct SetLiteral<E: PartialOrd> {
 	set: RangeList<E>,
 }
-/// Deserialisation function to resolve the encapsulation of set literals in the
+/// Deserialization function to resolve the encapsulation of set literals in the
 /// FlatZinc serialization format
 pub fn deserialize_encapsulated_set<'de, D: Deserializer<'de>, E: PartialOrd + Deserialize<'de>>(
 	deserializer: D,

--- a/crates/flatzinc-serde/src/encapsulate.rs
+++ b/crates/flatzinc-serde/src/encapsulate.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::RangeList;
+
+/// Encapsulated String helper struct
+#[derive(Deserialize, Serialize)]
+#[serde(rename = "string")]
+struct StringLiteral {
+	string: String,
+}
+/// Deserialisation function to resolve the encapsulation of string literals in
+/// the FlatZinc serialization format
+pub fn deserialize_encapsulated_string<'de, D: Deserializer<'de>>(
+	deserializer: D,
+) -> Result<String, D::Error> {
+	let s: StringLiteral = Deserialize::deserialize(deserializer)?;
+	Ok(s.string)
+}
+
+/// Serialization function to be used for the encapsulation of string literals
+/// required by the FlatZinc serialization format
+pub fn serialize_encapsulate_string<S: Serializer>(
+	s: &str,
+	serializer: S,
+) -> Result<S::Ok, S::Error> {
+	Serialize::serialize(
+		&StringLiteral {
+			string: String::from(s),
+		},
+		serializer,
+	)
+}
+
+// Encapsulated set helper struct
+#[derive(Deserialize, Serialize)]
+#[serde(rename = "set")]
+struct SetLiteral<E: PartialOrd> {
+	set: RangeList<E>,
+}
+/// Deserialisation function to resolve the encapsulation of set literals in the
+/// FlatZinc serialization format
+pub fn deserialize_encapsulated_set<'de, D: Deserializer<'de>, E: PartialOrd + Deserialize<'de>>(
+	deserializer: D,
+) -> Result<RangeList<E>, D::Error> {
+	let s: SetLiteral<E> = Deserialize::deserialize(deserializer)?;
+	Ok(s.set)
+}
+
+/// Serialization function to be used for the encapsulation of set literals
+/// required by the FlatZinc serialization format
+pub fn serialize_encapsulate_set<E: PartialOrd + Serialize + Clone, S: Serializer>(
+	r: &RangeList<E>,
+	serializer: S,
+) -> Result<S::Ok, S::Error> {
+	Serialize::serialize(&SetLiteral { set: r.clone() }, serializer)
+}

--- a/crates/flatzinc-serde/src/lib.rs
+++ b/crates/flatzinc-serde/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+	left + right
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn it_works() {
+		let result = add(2, 2);
+		assert_eq!(result, 4);
+	}
+}

--- a/crates/flatzinc-serde/src/lib.rs
+++ b/crates/flatzinc-serde/src/lib.rs
@@ -2,6 +2,9 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+mod range_list;
+pub use range_list::RangeList;
+
 /// Helper function to help skip in serialisation
 fn is_false(b: &bool) -> bool {
 	!(*b)
@@ -9,7 +12,7 @@ fn is_false(b: &bool) -> bool {
 
 /// Encapsulated String helper struct
 #[derive(Deserialize, Serialize)]
-#[serde(rename = "stringLiteral")]
+#[serde(rename = "string")]
 struct StringLiteral {
 	string: String,
 }
@@ -69,7 +72,7 @@ pub struct Call {
 	pub id: Identifier,
 }
 
-pub type Domain = Vec<Vec<i64>>;
+pub type Domain = RangeList<i64>;
 
 pub type Identifier = String;
 
@@ -101,9 +104,9 @@ pub enum Method {
 
 // TODO: Specialise for IntSet
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-#[serde(rename = "setLiteral")]
+#[serde(rename = "set")]
 pub struct SetLiteral {
-	pub set: Vec<Vec<f64>>,
+	pub set: RangeList<f64>,
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
@@ -157,6 +160,7 @@ mod tests {
 
 	test_file!(documentation_example);
 	test_file!(encapsulated_string);
+	test_file!(set_literals);
 
 	fn test_succesful_serialization(file: &Path, exp: ExpectFile) {
 		let rdr = BufReader::new(File::open(file).unwrap());

--- a/crates/flatzinc-serde/src/lib.rs
+++ b/crates/flatzinc-serde/src/lib.rs
@@ -97,6 +97,19 @@ pub enum Method {
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "type")]
+pub enum Type {
+	#[serde(rename = "bool")]
+	Bool,
+	#[serde(rename = "int")]
+	Int,
+	#[serde(rename = "float")]
+	Float,
+	#[serde(rename = "set of int")]
+	IntSet,
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "variable")]
 pub struct Variable {
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -110,7 +123,7 @@ pub struct Variable {
 	#[serde(rename = "rhs", skip_serializing_if = "Option::is_none")]
 	pub value: Option<Literal>,
 	#[serde(rename = "type")]
-	pub ty: String,
+	pub ty: Type,
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]

--- a/crates/flatzinc-serde/src/lib.rs
+++ b/crates/flatzinc-serde/src/lib.rs
@@ -1,3 +1,85 @@
+//! Serialization of the FlatZinc data format
+//!
+//! FlatZinc is the langauge in which data and solver specific constraint models
+//! are produced by the [MiniZinc](https://www.minizinc.org) compiler. This
+//! crate implements the FlatZinc serialization format as described in the
+//! [Interfacing Solvers to
+//! FlatZinc](https://www.minizinc.org/doc-latest/en/fzn-spec.html#specification-of-flatzinc-json)
+//! section of the MiniZinc reference manual. Although the
+//! [serde](https://serde.rs) specification in this crate could be used with a
+//! range of data formats, MiniZinc currently only outputs this formulation
+//! using the JSON data format. We suggest using
+//! [`serde_json`](https://crates.io/crates/serde_json) with the specification
+//! in this crate to parse the FlatZinc JSON files produced by the MiniZinc
+//! compiler.
+//!
+//! # Getting Started
+//!
+//! Install `flatzinc_serde` and `serde_json` for your package:
+//!
+//! ```bash
+//! cargo add flatzinc_serde serde_json
+//! ```
+//!
+//! Once these dependencies have been installed to your crate, you could
+//! deserialize a FlatZinc JSON file as follows:
+//!
+//! ```
+//! # use flatzinc_serde::FlatZinc;
+//! # use std::{fs::File, io::BufReader, path::Path};
+//! # let path = Path::new("./corpus/documentation_example.fzn.json");
+//! // let path = Path::new("/lorem/ipsum/model.fzn.json");
+//! let rdr = BufReader::new(File::open(path).unwrap());
+//! let fzn: FlatZinc = serde_json::from_reader(rdr).unwrap();
+//! // ... process FlatZinc ...
+//! ```
+//!
+//! If, however, you want to serialize a FlatZinc format you could follow the
+//! following fragment:
+//!
+//! ```
+//! # use flatzinc_serde::FlatZinc;
+//! let fzn = FlatZinc::default();
+//! // ... creat solver constraint model ...
+//! let json_str = serde_json::to_string(&fzn).unwrap();
+//! ```
+//! Note that `serde_json::to_writer`, using a buffered file writer, would be
+//! preferred when writing larger FlatZinc files.
+//!
+//! # Register your solver with MiniZinc
+//!
+//! If your goal is to deserialize FlatZinc to implement a MiniZinc solver, then
+//! the next step is to register your solver executable with MiniZinc. This can
+//! be done by creating a [MiniZinc Solver
+//! Configuration](https://www.minizinc.org/doc-2.8.2/en/fzn-spec.html#solver-configuration-files)
+//! (`.mzc`) file, and adding it to a folder on the `MZN_SOLVER_PATH` or a
+//! standardized path, like `~/.minizinc/solvers/`. A basic solver configuation
+//! for a solver that accepts JSON input would look as follows:
+//!
+//! ```json
+//! {
+//!   "name" : "My Solver",
+//!   "version": "0.0.1",
+//!   "id": "my.organisation.mysolver",
+//!   "inputType": "JSON",
+//!   "executable": "../../../bin/fzn-my-solver",
+//!   "mznlib": "../mysolver"
+//!   "stdFlags": [],
+//!   "extraFlags": []
+//! }
+//! ```
+//!
+//! Once you have placed your configuation file on the correct path, then you
+//! solver will be listed by `minizinc --solvers`. Calling `minizinc --solver
+//! mysolver model.mzn data.dzn`, assuming a valid MiniZinc instance, will
+//! (after compilation) invoke the registered executable with a path of a
+//! FlatZinc JSON file, and potentially any registered standard and extra flags
+//! (e.g., `../../../bin/fzn-my-solver model.fzn.json`).
+
+#![warn(missing_docs)]
+#![warn(unused_crate_dependencies, unused_extern_crates)]
+#![warn(variant_size_differences)]
+
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
@@ -16,138 +98,242 @@ fn is_false(b: &bool) -> bool {
 	!(*b)
 }
 
+/// Additional information provided in a standardized format for declarations,
+/// constraints, or solve objectives
+///
+/// In MiniZinc annotations can both be added explicitly in the model, or can be
+/// added during compilation process.
+///
+/// Note that annotations are generally defined either in the MiniZinc standard
+/// library or in a solver's redefinition library. Solvers are encouraged to
+/// rewrite annotations in their redefinitions library when required.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Annotation {
+	/// Atom annotation (i.e., a single [`Identifier`])
+	Atom(Identifier),
+	/// Call annotation
 	Call(Call),
-	Atom(String),
 }
 
+/// A definition of a named array literal in FlatZinc
+///
+/// FlatZinc Arrays are a simple (one-dimensional) sequence of [`Literal`]s.
+/// These values are stored as the [`Array::contents`] member. Additional
+/// information, in the form of [`Annotation`]s, from the MiniZinc model is
+/// stored in [`Array::ann`] when present. When [`Array::defined`] is set to
+/// `true`, then
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "array")]
 pub struct Array {
+	/// The values stored within the array literal
 	#[serde(rename = "a")]
 	pub contents: Vec<Literal>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	/// List of annotations
 	pub ann: Vec<Annotation>,
 	#[serde(default, skip_serializing_if = "is_false")]
+	/// This field is set to `true` when there is a constraint that has been marked as
+	/// defining this array.
 	pub defined: bool,
 	#[serde(default, skip_serializing_if = "is_false")]
+	/// This field is set to `true` when the array has been introduced by the
+	/// MiniZinc compiler, rather than being explicitly defined at the top-level
+	/// of the MiniZinc model.
 	pub introduced: bool,
 }
 
+/// The argument type associated with [`Call`]
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Argument {
+	/// Sequence of [`Literal`]s
 	Array(Vec<Literal>),
+	/// Literal
 	Literal(Literal),
 }
 
+/// An object depicting a call, used for constraints and annotations
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "call")]
 pub struct Call {
+	/// Identifier of the function being called (e.g., a predicate or annotation)
+	pub id: Identifier,
+	/// Arguments of the call
+	pub args: Vec<Argument>,
+	/// List of annotations
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub ann: Vec<Annotation>,
-	pub args: Vec<Argument>,
-	pub id: Identifier,
 }
 
+/// The posible values that a (decision) [`Variable`] can take
+///
+/// In the case of a integer or floating point variable, a solution for the FlatZinc instance must
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Domain {
+	/// Integer (or set of integer) decision variable domain
 	Int(RangeList<i64>),
+	/// Floating point decision variable domain
 	Float(RangeList<f64>),
 }
 
+/// A name used to refer to an [`Array`], function, or [`Variable`]
 pub type Identifier = String;
 
+/// Literal values
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Literal {
+	/// Integer value
 	Int(i64),
+	/// Floating point value
 	Float(f64),
+	/// Identifier, i.e., reference to an [`Array`] or [`Variable`]
 	Identifier(Identifier),
+	/// Boolean value
 	Bool(bool),
 	#[serde(
 		serialize_with = "serialize_encapsulate_set",
 		deserialize_with = "deserialize_encapsulated_set"
 	)]
+	/// Set of integers, represented as a list of integer ranges
 	IntSet(RangeList<i64>),
 	#[serde(
 		serialize_with = "serialize_encapsulate_set",
 		deserialize_with = "deserialize_encapsulated_set"
 	)]
+	/// Set of floating point values, represented as a list of floating point
+	/// ranges
 	FloatSet(RangeList<f64>),
 	#[serde(
 		serialize_with = "serialize_encapsulate_string",
 		deserialize_with = "deserialize_encapsulated_string"
 	)]
+	/// String value
 	String(String),
 }
 
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+/// Goal of solving a FlatZinc instance
+#[derive(Default, Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "method")]
 pub enum Method {
+	/// Find any solution
 	#[serde(rename = "satisfy")]
+	#[default]
 	Satisfy,
+	/// Find the solution with the lowest objective value
 	#[serde(rename = "minimize")]
 	Minimize,
+	/// Find the solution with the highest objective value
 	#[serde(rename = "maximize")]
 	Maximize,
 }
 
+/// Used to signal the type of (decision) [`Variable`]
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "type")]
 pub enum Type {
+	/// Boolean decision variable
 	#[serde(rename = "bool")]
 	Bool,
+	/// Integer decision variable
 	#[serde(rename = "int")]
 	Int,
+	/// Floating point decision variable
 	#[serde(rename = "float")]
 	Float,
+	/// Integer set decision variable
 	#[serde(rename = "set of int")]
 	IntSet,
 }
 
+/// The definition of a decision variable
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename = "variable")]
 pub struct Variable {
-	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	pub ann: Vec<Annotation>,
-	#[serde(default, skip_serializing_if = "is_false")]
-	pub defined: bool,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub domain: Option<Domain>,
-	#[serde(default, skip_serializing_if = "is_false")]
-	pub introduced: bool,
-	#[serde(rename = "rhs", skip_serializing_if = "Option::is_none")]
-	pub value: Option<Literal>,
+	/// The type of the decision variable
 	#[serde(rename = "type")]
 	pub ty: Type,
-}
-
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-pub struct SolveObjective {
+	/// The set of potential values from which the decision variable must take its
+	/// value in a solution
+	///
+	/// If domain has the value `None`, then all values of the decision variable's
+	/// `Type` are allowed in a solution.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub domain: Option<Domain>,
+	/// The “right hand side” of the variable, i.e., its value or alias to another
+	/// variable
+	#[serde(rename = "rhs", skip_serializing_if = "Option::is_none")]
+	pub value: Option<Literal>,
+	/// A list of annotations
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub ann: Vec<Annotation>,
-	pub method: Method,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub objective: Option<Literal>,
+	/// This field is set to `true` when there is a constraint that has been marked as
+	/// defining this variable.
+	#[serde(default, skip_serializing_if = "is_false")]
+	pub defined: bool,
+	/// This field is set to `true` when the variable has been introduced by the
+	/// MiniZinc compiler, rather than being explicitly defined at the top-level
+	/// of the MiniZinc model.
+	#[serde(default, skip_serializing_if = "is_false")]
+	pub introduced: bool,
 }
 
+/// A specification of objective of a FlatZinc instance
+#[derive(Default, Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct SolveObjective {
+	/// The type of goal
+	pub method: Method,
+	/// The variable to optimize, or `None` if [`SolveObjective::method`] is [`Method::Satisfy`]
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub objective: Option<Literal>,
+	/// A list of annatations from the solve statement in the MiniZinc model
+	///
+	/// Note that this includes the search annotations if they are present in the
+	/// model.
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub ann: Vec<Annotation>,
+}
+
+/// The structure depicting a FlatZinc instance
+///
+/// FlatZinc is (generally) a format produced by the MiniZinc compiler as a
+/// result of instantiating the parameter variables of a MiniZinc model and
+/// generating a solver-specific equisatisfiable model.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct FlatZinc {
+	/// A mapping from decision variable [`Identifier`] to their definitions
 	#[serde(default)]
-	pub arrays: BTreeMap<String, Array>,
+	pub variables: BTreeMap<Identifier, Variable>,
+	/// A mapping from array [`Identifier`] to their definitions
+	#[serde(default)]
+	pub arrays: BTreeMap<Identifier, Array>,
+	/// A list of (solver-specific) constraints, in the form of [`Call`] objects,
+	/// that must be satisfied in a solution.
 	#[serde(default)]
 	pub constraints: Vec<Call>,
+	/// A list of all identifiers for which the solver must produce output for each solution
 	#[serde(default)]
 	pub output: Vec<Identifier>,
+	/// A specification of the goal of solving the FlatZinc instance.
 	pub solve: SolveObjective,
-	#[serde(default)]
-	pub variables: BTreeMap<String, Variable>,
+	/// The version of the FlatZinc serialization specifation used
 	#[serde(default, skip_serializing_if = "String::is_empty")]
 	pub version: String,
+}
+
+impl Default for FlatZinc {
+	fn default() -> Self {
+		Self {
+			variables: Default::default(),
+			arrays: Default::default(),
+			constraints: Default::default(),
+			output: Default::default(),
+			solve: Default::default(),
+			version: "1.0".into(),
+		}
+	}
 }
 
 #[cfg(test)]

--- a/crates/flatzinc-serde/src/lib.rs
+++ b/crates/flatzinc-serde/src/lib.rs
@@ -1,6 +1,6 @@
 //! Serialization of the FlatZinc data format
 //!
-//! FlatZinc is the langauge in which data and solver specific constraint models
+//! FlatZinc is the language in which data and solver specific constraint models
 //! are produced by the [MiniZinc](https://www.minizinc.org) compiler. This
 //! crate implements the FlatZinc serialization format as described in the
 //! [Interfacing Solvers to
@@ -53,7 +53,7 @@
 //! be done by creating a [MiniZinc Solver
 //! Configuration](https://www.minizinc.org/doc-2.8.2/en/fzn-spec.html#solver-configuration-files)
 //! (`.mzc`) file, and adding it to a folder on the `MZN_SOLVER_PATH` or a
-//! standardized path, like `~/.minizinc/solvers/`. A basic solver configuation
+//! standardized path, like `~/.minizinc/solvers/`. A basic solver configuration
 //! for a solver that accepts JSON input would look as follows:
 //!
 //! ```json
@@ -69,7 +69,7 @@
 //! }
 //! ```
 //!
-//! Once you have placed your configuation file on the correct path, then you
+//! Once you have placed your configuration file on the correct path, then you
 //! solver will be listed by `minizinc --solvers`. Calling `minizinc --solver
 //! mysolver model.mzn data.dzn`, assuming a valid MiniZinc instance, will
 //! (after compilation) invoke the registered executable with a path of a
@@ -93,7 +93,7 @@ mod range_list;
 pub use range_list::RangeList;
 mod encapsulate;
 
-/// Helper function to help skip in serialisation
+/// Helper function to help skip in serialization
 fn is_false(b: &bool) -> bool {
 	!(*b)
 }
@@ -166,7 +166,7 @@ pub struct Call {
 	pub ann: Vec<Annotation>,
 }
 
-/// The posible values that a (decision) [`Variable`] can take
+/// The possible values that a (decision) [`Variable`] can take
 ///
 /// In the case of a integer or floating point variable, a solution for the FlatZinc instance must
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
@@ -288,7 +288,7 @@ pub struct SolveObjective {
 	/// The variable to optimize, or `None` if [`SolveObjective::method`] is [`Method::Satisfy`]
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub objective: Option<Literal>,
-	/// A list of annatations from the solve statement in the MiniZinc model
+	/// A list of annotations from the solve statement in the MiniZinc model
 	///
 	/// Note that this includes the search annotations if they are present in the
 	/// model.
@@ -318,7 +318,7 @@ pub struct FlatZinc {
 	pub output: Vec<Identifier>,
 	/// A specification of the goal of solving the FlatZinc instance.
 	pub solve: SolveObjective,
-	/// The version of the FlatZinc serialization specifation used
+	/// The version of the FlatZinc serialization specification used
 	#[serde(default, skip_serializing_if = "String::is_empty")]
 	pub version: String,
 }
@@ -349,7 +349,7 @@ mod tests {
 	test_file!(float_sets);
 	test_file!(set_literals);
 
-	fn test_succesful_serialization(file: &Path, exp: ExpectFile) {
+	fn test_successful_serialization(file: &Path, exp: ExpectFile) {
 		let rdr = BufReader::new(File::open(file).unwrap());
 		let fzn: FlatZinc = serde_json::from_reader(rdr).unwrap();
 		exp.assert_debug_eq(&fzn);
@@ -361,7 +361,7 @@ mod tests {
 		($file: ident) => {
 			#[test]
 			fn $file() {
-				test_succesful_serialization(
+				test_successful_serialization(
 					std::path::Path::new(&format!("./corpus/{}.fzn.json", stringify!($file))),
 					expect_test::expect_file![&format!(
 						"../corpus/{}.debug.txt",

--- a/crates/flatzinc-serde/src/lib.rs
+++ b/crates/flatzinc-serde/src/lib.rs
@@ -1,14 +1,389 @@
-pub fn add(left: usize, right: usize) -> usize {
-	left + right
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Helper function to help skip in serialisation
+fn is_false(b: &bool) -> bool {
+	!(*b)
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Annotation {
+	Call(Call),
+	Atom(String),
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "array")]
+pub struct Array {
+	#[serde(rename = "a")]
+	pub contents: Vec<Literal>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub ann: Vec<Annotation>,
+	#[serde(default, skip_serializing_if = "is_false")]
+	pub defined: bool,
+	#[serde(default, skip_serializing_if = "is_false")]
+	pub introduced: bool,
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Argument {
+	Array(Vec<Literal>),
+	Literal(Literal),
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "call")]
+pub struct Call {
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub ann: Vec<Annotation>,
+	pub args: Vec<Argument>,
+	pub id: Identifier,
+}
+
+pub type Domain = Vec<Vec<i64>>;
+
+pub type Identifier = String;
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Literal {
+	Int(i64),
+	Float(f64),
+	Identifier(Identifier),
+	Bool(bool),
+	Set(SetLiteral),
+	String(StringLiteral),
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "method")]
+pub enum Method {
+	#[serde(rename = "satisfy")]
+	Satisfy,
+	#[serde(rename = "minimize")]
+	Minimize,
+	#[serde(rename = "maximize")]
+	Maximize,
+}
+
+// TODO: Specialise for IntSet
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "setLiteral")]
+pub struct SetLiteral {
+	pub set: Vec<Vec<f64>>,
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "stringLiteral")]
+pub struct StringLiteral {
+	pub string: String,
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename = "variable")]
+pub struct Variable {
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub ann: Vec<Annotation>,
+	#[serde(default, skip_serializing_if = "is_false")]
+	pub defined: bool,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub domain: Option<Domain>,
+	#[serde(default, skip_serializing_if = "is_false")]
+	pub introduced: bool,
+	#[serde(rename = "rhs", skip_serializing_if = "Option::is_none")]
+	pub value: Option<Literal>,
+	#[serde(rename = "type")]
+	pub ty: String,
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct SolveObjective {
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub ann: Vec<Annotation>,
+	pub method: Method,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub objective: Option<Literal>,
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct FlatZinc {
+	#[serde(default)]
+	pub arrays: BTreeMap<String, Array>,
+	#[serde(default)]
+	pub constraints: Vec<Call>,
+	#[serde(default)]
+	pub output: Vec<Identifier>,
+	pub solve: SolveObjective,
+	#[serde(default)]
+	pub variables: BTreeMap<String, Variable>,
+	#[serde(default, skip_serializing_if = "String::is_empty")]
+	pub version: String,
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+	use expect_test::expect;
+
+	use crate::FlatZinc;
 
 	#[test]
-	fn it_works() {
-		let result = add(2, 2);
-		assert_eq!(result, 4);
+	fn documentation_example() {
+		const FROM_DOCS: &str = r#"
+		{
+			"variables": {
+				"b" : { "type" : "int", "domain" : [[0, 3]] },
+				"c" : { "type" : "int", "domain" : [[0, 6]] },
+				"X_INTRODUCED_0_" : { "type" : "int", "domain" : [[0, 85000]], "defined" : true }
+			},
+			"arrays": {
+				"X_INTRODUCED_2_" : { "a": [250, 200] },
+				"X_INTRODUCED_6_" : { "a": [75, 150] },
+				"X_INTRODUCED_8_" : { "a": [100, 150] }
+			},
+			"constraints": [
+				{ "id" : "int_lin_le", "args" : ["X_INTRODUCED_2_", ["b", "c"], 4000]},
+				{ "id" : "int_lin_le", "args" : ["X_INTRODUCED_6_", ["b", "c"], 2000]},
+				{ "id" : "int_lin_le", "args" : ["X_INTRODUCED_8_", ["b", "c"], 500]},
+				{ "id" : "int_lin_eq", "args" : [[400, 450, -1], ["b", "c", "X_INTRODUCED_0_"], 0],
+					"ann" : ["ctx_pos"], "defines" : "X_INTRODUCED_0_"}
+			],
+			"output": ["b", "c"],
+			"solve": { "method" : "maximize", "objective" : "X_INTRODUCED_0_" },
+			"verson": "1.0"
+		}"#;
+		let fzn: FlatZinc = serde_json::from_str(FROM_DOCS).unwrap();
+		expect![[r#"
+    FlatZinc {
+        arrays: {
+            "X_INTRODUCED_2_": Array {
+                contents: [
+                    Int(
+                        250,
+                    ),
+                    Int(
+                        200,
+                    ),
+                ],
+                ann: [],
+                defined: false,
+                introduced: false,
+            },
+            "X_INTRODUCED_6_": Array {
+                contents: [
+                    Int(
+                        75,
+                    ),
+                    Int(
+                        150,
+                    ),
+                ],
+                ann: [],
+                defined: false,
+                introduced: false,
+            },
+            "X_INTRODUCED_8_": Array {
+                contents: [
+                    Int(
+                        100,
+                    ),
+                    Int(
+                        150,
+                    ),
+                ],
+                ann: [],
+                defined: false,
+                introduced: false,
+            },
+        },
+        constraints: [
+            Call {
+                ann: [],
+                args: [
+                    Literal(
+                        Identifier(
+                            "X_INTRODUCED_2_",
+                        ),
+                    ),
+                    Array(
+                        [
+                            Identifier(
+                                "b",
+                            ),
+                            Identifier(
+                                "c",
+                            ),
+                        ],
+                    ),
+                    Literal(
+                        Int(
+                            4000,
+                        ),
+                    ),
+                ],
+                id: "int_lin_le",
+            },
+            Call {
+                ann: [],
+                args: [
+                    Literal(
+                        Identifier(
+                            "X_INTRODUCED_6_",
+                        ),
+                    ),
+                    Array(
+                        [
+                            Identifier(
+                                "b",
+                            ),
+                            Identifier(
+                                "c",
+                            ),
+                        ],
+                    ),
+                    Literal(
+                        Int(
+                            2000,
+                        ),
+                    ),
+                ],
+                id: "int_lin_le",
+            },
+            Call {
+                ann: [],
+                args: [
+                    Literal(
+                        Identifier(
+                            "X_INTRODUCED_8_",
+                        ),
+                    ),
+                    Array(
+                        [
+                            Identifier(
+                                "b",
+                            ),
+                            Identifier(
+                                "c",
+                            ),
+                        ],
+                    ),
+                    Literal(
+                        Int(
+                            500,
+                        ),
+                    ),
+                ],
+                id: "int_lin_le",
+            },
+            Call {
+                ann: [
+                    Atom(
+                        "ctx_pos",
+                    ),
+                ],
+                args: [
+                    Array(
+                        [
+                            Int(
+                                400,
+                            ),
+                            Int(
+                                450,
+                            ),
+                            Int(
+                                -1,
+                            ),
+                        ],
+                    ),
+                    Array(
+                        [
+                            Identifier(
+                                "b",
+                            ),
+                            Identifier(
+                                "c",
+                            ),
+                            Identifier(
+                                "X_INTRODUCED_0_",
+                            ),
+                        ],
+                    ),
+                    Literal(
+                        Int(
+                            0,
+                        ),
+                    ),
+                ],
+                id: "int_lin_eq",
+            },
+        ],
+        output: [
+            "b",
+            "c",
+        ],
+        solve: SolveObjective {
+            ann: [],
+            method: Maximize,
+            objective: Some(
+                Identifier(
+                    "X_INTRODUCED_0_",
+                ),
+            ),
+        },
+        variables: {
+            "X_INTRODUCED_0_": Variable {
+                ann: [],
+                defined: true,
+                domain: Some(
+                    [
+                        [
+                            0,
+                            85000,
+                        ],
+                    ],
+                ),
+                introduced: false,
+                value: None,
+                ty: "int",
+            },
+            "b": Variable {
+                ann: [],
+                defined: false,
+                domain: Some(
+                    [
+                        [
+                            0,
+                            3,
+                        ],
+                    ],
+                ),
+                introduced: false,
+                value: None,
+                ty: "int",
+            },
+            "c": Variable {
+                ann: [],
+                defined: false,
+                domain: Some(
+                    [
+                        [
+                            0,
+                            6,
+                        ],
+                    ],
+                ),
+                introduced: false,
+                value: None,
+                ty: "int",
+            },
+        },
+        version: "",
+    }
+"#]]
+		.assert_debug_eq(&fzn);
+		let fzn2: FlatZinc = serde_json::from_str(&serde_json::to_string(&fzn).unwrap()).unwrap();
+		assert_eq!(fzn, fzn2)
 	}
 }

--- a/crates/flatzinc-serde/src/range_list.rs
+++ b/crates/flatzinc-serde/src/range_list.rs
@@ -1,0 +1,173 @@
+use std::{fmt::Debug, iter::Map, ops::RangeInclusive};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RangeList<E: PartialOrd> {
+	ranges: Vec<(E, E)>,
+}
+
+impl<E: PartialOrd> Default for RangeList<E> {
+	fn default() -> Self {
+		Self { ranges: Vec::new() }
+	}
+}
+
+impl<E: PartialOrd + Debug> Debug for RangeList<E> {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "RangeList::from_iter([")?;
+		let mut first = true;
+		for r in self {
+			if !first {
+				write!(f, ", ")?
+			}
+			write!(f, "{:?}", r)?;
+			first = false;
+		}
+		write!(f, "])")
+	}
+}
+
+impl<E: PartialOrd + Clone> IntoIterator for RangeList<E> {
+	type Item = RangeInclusive<E>;
+	type IntoIter = Map<std::vec::IntoIter<(E, E)>, fn((E, E)) -> RangeInclusive<E>>;
+
+	fn into_iter(self) -> Self::IntoIter {
+		self.ranges
+			.into_iter()
+			.map(|(start, end)| RangeInclusive::new(start, end))
+	}
+}
+impl<'a, E: PartialOrd> IntoIterator for &'a RangeList<E> {
+	type Item = RangeInclusive<&'a E>;
+	type IntoIter = Map<std::slice::Iter<'a, (E, E)>, fn(&'a (E, E)) -> RangeInclusive<&'a E>>;
+
+	fn into_iter(self) -> Self::IntoIter {
+		self.ranges
+			.iter()
+			.map(|(start, end)| RangeInclusive::new(start, end))
+	}
+}
+impl<E: PartialOrd + Clone> From<&RangeInclusive<E>> for RangeList<E> {
+	fn from(value: &RangeInclusive<E>) -> Self {
+		if value.is_empty() {
+			Self::default()
+		} else {
+			Self {
+				ranges: vec![(value.start().clone(), value.end().clone())],
+			}
+		}
+	}
+}
+impl<E: PartialOrd + Clone> From<RangeInclusive<E>> for RangeList<E> {
+	fn from(value: RangeInclusive<E>) -> Self {
+		(&value).into()
+	}
+}
+impl<E: PartialOrd + Clone> FromIterator<RangeInclusive<E>> for RangeList<E> {
+	fn from_iter<T: IntoIterator<Item = RangeInclusive<E>>>(iter: T) -> Self {
+		let mut non_empty: Vec<(E, E)> = iter
+			.into_iter()
+			.filter_map(|r| {
+				if r.is_empty() {
+					None
+				} else {
+					Some((r.start().clone(), r.end().clone()))
+				}
+			})
+			.collect();
+		if non_empty.is_empty() {
+			return RangeList::default();
+		}
+		non_empty.sort_by(|a, b| {
+			a.0.partial_cmp(&b.0)
+				.expect("the order of the bounds in the RangeList cannot be partial")
+		});
+		let mut it = non_empty.into_iter();
+		let mut ranges = Vec::new();
+		let mut cur = it.next().unwrap();
+		for next in it {
+			if cur.1 >= next.0 {
+				cur.1 = next.1
+			} else {
+				ranges.push(cur);
+				cur = next;
+			}
+		}
+		ranges.push(cur);
+		Self { ranges }
+	}
+}
+
+impl<E: PartialOrd> RangeList<E> {
+	pub fn is_empty(&self) -> bool {
+		self.ranges.is_empty()
+	}
+
+	pub fn contains(&self, item: &E) -> bool {
+		for r in self {
+			if r.contains(&item) {
+				return true;
+			}
+		}
+		false
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use expect_test::expect;
+
+	use super::*;
+
+	#[test]
+	fn test_rangelist() {
+		let empty: RangeList<i64> = RangeList::default();
+		expect![[r#"
+    RangeList::from_iter([])
+"#]]
+		.assert_debug_eq(&empty);
+		assert!(empty.is_empty());
+
+		let single_range = RangeList::from_iter([1..=4]);
+		expect![[r#"
+    RangeList::from_iter([1..=4])
+"#]]
+		.assert_debug_eq(&single_range);
+		assert!(!single_range.is_empty());
+		assert!(single_range.contains(&1));
+		assert!(single_range.contains(&2));
+		assert!(single_range.contains(&4));
+		assert!(!single_range.contains(&0));
+		assert!(!single_range.contains(&5));
+
+		let multi_range = RangeList::from_iter([1..=4, 6..=7, -5..=-3]);
+		expect![[r#"
+    RangeList::from_iter([-5..=-3, 1..=4, 6..=7])
+"#]]
+		.assert_debug_eq(&multi_range);
+		assert!(multi_range.contains(&-5));
+		assert!(multi_range.contains(&-3));
+		assert!(multi_range.contains(&1));
+		assert!(multi_range.contains(&4));
+		assert!(multi_range.contains(&6));
+		assert!(multi_range.contains(&7));
+		assert!(!multi_range.contains(&0));
+		assert!(!multi_range.contains(&5));
+		assert!(!multi_range.contains(&-6));
+		assert!(!multi_range.contains(&8));
+
+		let collapse_range = RangeList::from_iter([1..=2, 2..=3, 10..=12, 11..=15]);
+		expect![[r#"
+    RangeList::from_iter([1..=3, 10..=15])
+"#]]
+		.assert_debug_eq(&collapse_range);
+
+		let float_range = RangeList::from_iter([0.1..=3.2, 8.1..=11.2, 10.0..=50.0]);
+		expect![[r#"
+    RangeList::from_iter([0.1..=3.2, 8.1..=50.0])
+"#]]
+		.assert_debug_eq(&float_range);
+	}
+}

--- a/crates/flatzinc-serde/src/range_list.rs
+++ b/crates/flatzinc-serde/src/range_list.rs
@@ -140,6 +140,38 @@ impl<E: PartialOrd> RangeList<E> {
 		}
 		false
 	}
+
+	/// Returns the lower bound of the range list, or `None` if the range list is
+	/// empty.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// # use flatzinc_serde::RangeList;
+	/// assert_eq!(RangeList::from_iter([1..=4]).lower_bound(), Some(&1));
+	/// assert_eq!(RangeList::from_iter([1..=4, 6..=7, -5..=-3]).lower_bound(), Some(&-5));
+	///
+	/// assert_eq!(RangeList::<i64>::from_iter([]).lower_bound(), None);
+	/// ```
+	pub fn lower_bound(&self) -> Option<&E> {
+		self.ranges.first().map(|(start, _)| start)
+	}
+
+	/// Returns the upper bound of the range list, or `None` if the range list is
+	/// empty
+	///
+	/// # Examples
+	///
+	/// ```
+	/// # use flatzinc_serde::RangeList;
+	/// assert_eq!(RangeList::from_iter([1..=4]).upper_bound(), Some(&4));
+	/// assert_eq!(RangeList::from_iter([1..=4, 6..=7, -5..=-3]).upper_bound(), Some(&7));
+	///
+	/// assert_eq!(RangeList::<i64>::from_iter([]).upper_bound(), None);
+	/// ```
+	pub fn upper_bound(&self) -> Option<&E> {
+		self.ranges.last().map(|(_, end)| end)
+	}
 }
 
 #[cfg(test)]

--- a/crates/shackle-compiler/src/diagnostics/error.rs
+++ b/crates/shackle-compiler/src/diagnostics/error.rs
@@ -598,9 +598,9 @@ pub enum Error {
 	InternalError(#[from] InternalError),
 }
 
-/// Unable to convert an empty vector into a [`ShackleError`]
+/// Unable to convert an empty vector into a [`crate::Error`]
 #[derive(Error, Debug, Diagnostic, PartialEq, Eq, Clone)]
-#[error("Unable to convert empty vector to a ShackleError")]
+#[error("Unable to convert empty vector into a Error")]
 #[diagnostic(code(shackle::empty_error_vec))]
 pub struct EmptyErrorVec;
 


### PR DESCRIPTION
This adds a crate that can be used to consume and produce the FlatZinc JSON format released with recent versions of MiniZinc.

The crate is self-contained and only depends on `serde` for the serialization itself. Users of the crate will likely also have to depend on `serde_json`, as documented.