### PR TITLE
Update FlatZinc JSON to support "defines" 

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -76,3 +76,14 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.4
       - name: Run clippy
         run: cargo clippy -- -D warnings
+  semver-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: flatzinc-serde
+        env:
+          RUSTC_WRAPPER: ""

--- a/crates/flatzinc-serde/Cargo.toml
+++ b/crates/flatzinc-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatzinc-serde"
-version = "0.2.0"
+version = "0.3.0"
 description = "FlatZinc serialization and deserialization"
 authors = [
   "Jip J. Dekker <jip@dekker.one>",

--- a/crates/flatzinc-serde/corpus/documentation_example.debug.txt
+++ b/crates/flatzinc-serde/corpus/documentation_example.debug.txt
@@ -79,7 +79,7 @@ FlatZinc {
         },
     },
     constraints: [
-        Call {
+        Constraint {
             id: "int_lin_le",
             args: [
                 Literal(
@@ -103,9 +103,10 @@ FlatZinc {
                     ),
                 ),
             ],
+            defines: None,
             ann: [],
         },
-        Call {
+        Constraint {
             id: "int_lin_le",
             args: [
                 Literal(
@@ -129,9 +130,10 @@ FlatZinc {
                     ),
                 ),
             ],
+            defines: None,
             ann: [],
         },
-        Call {
+        Constraint {
             id: "int_lin_le",
             args: [
                 Literal(
@@ -155,9 +157,10 @@ FlatZinc {
                     ),
                 ),
             ],
+            defines: None,
             ann: [],
         },
-        Call {
+        Constraint {
             id: "int_lin_eq",
             args: [
                 Array(
@@ -192,6 +195,9 @@ FlatZinc {
                     ),
                 ),
             ],
+            defines: Some(
+                "X_INTRODUCED_0_",
+            ),
             ann: [
                 Atom(
                     "ctx_pos",

--- a/crates/flatzinc-serde/corpus/documentation_example.debug_ustr.txt
+++ b/crates/flatzinc-serde/corpus/documentation_example.debug_ustr.txt
@@ -79,7 +79,7 @@ FlatZinc {
         },
     },
     constraints: [
-        Call {
+        Constraint {
             id: u!("int_lin_le"),
             args: [
                 Literal(
@@ -103,9 +103,10 @@ FlatZinc {
                     ),
                 ),
             ],
+            defines: None,
             ann: [],
         },
-        Call {
+        Constraint {
             id: u!("int_lin_le"),
             args: [
                 Literal(
@@ -129,9 +130,10 @@ FlatZinc {
                     ),
                 ),
             ],
+            defines: None,
             ann: [],
         },
-        Call {
+        Constraint {
             id: u!("int_lin_le"),
             args: [
                 Literal(
@@ -155,9 +157,10 @@ FlatZinc {
                     ),
                 ),
             ],
+            defines: None,
             ann: [],
         },
-        Call {
+        Constraint {
             id: u!("int_lin_eq"),
             args: [
                 Array(
@@ -192,6 +195,9 @@ FlatZinc {
                     ),
                 ),
             ],
+            defines: Some(
+                u!("X_INTRODUCED_0_"),
+            ),
             ann: [
                 Atom(
                     u!("ctx_pos"),

--- a/crates/flatzinc-serde/corpus/documentation_example.fzn
+++ b/crates/flatzinc-serde/corpus/documentation_example.fzn
@@ -7,5 +7,5 @@ array[1..2] of int: X_INTRODUCED_8_ = [100, 150];
 constraint int_lin_le(X_INTRODUCED_2_, [b, c], 4000);
 constraint int_lin_le(X_INTRODUCED_6_, [b, c], 2000);
 constraint int_lin_le(X_INTRODUCED_8_, [b, c], 500);
-constraint int_lin_eq([400, 450, -1], [b, c, X_INTRODUCED_0_], 0) ::ctx_pos;
+constraint int_lin_eq([400, 450, -1], [b, c, X_INTRODUCED_0_], 0) ::defines_var(X_INTRODUCED_0_) ::ctx_pos;
 solve maximize X_INTRODUCED_0_;

--- a/crates/flatzinc-serde/corpus/encapsulated_string.debug.txt
+++ b/crates/flatzinc-serde/corpus/encapsulated_string.debug.txt
@@ -8,16 +8,17 @@ FlatZinc {
         objective: None,
         ann: [
             Call(
-                Call {
+                AnnotationCall {
                     id: "myAnn",
                     args: [
                         Literal(
-                            String(
-                                "my string",
+                            Literal(
+                                String(
+                                    "my string",
+                                ),
                             ),
                         ),
                     ],
-                    ann: [],
                 },
             ),
         ],

--- a/crates/flatzinc-serde/corpus/encapsulated_string.debug.txt
+++ b/crates/flatzinc-serde/corpus/encapsulated_string.debug.txt
@@ -12,7 +12,7 @@ FlatZinc {
                     id: "myAnn",
                     args: [
                         Literal(
-                            Literal(
+                            BaseLiteral(
                                 String(
                                     "my string",
                                 ),

--- a/crates/flatzinc-serde/corpus/float_sets.debug.txt
+++ b/crates/flatzinc-serde/corpus/float_sets.debug.txt
@@ -35,7 +35,7 @@ FlatZinc {
     },
     arrays: {},
     constraints: [
-        Call {
+        Constraint {
             id: "my_float_in",
             args: [
                 Literal(
@@ -49,9 +49,10 @@ FlatZinc {
                     ),
                 ),
             ],
+            defines: None,
             ann: [],
         },
-        Call {
+        Constraint {
             id: "set_in_reif",
             args: [
                 Literal(
@@ -70,6 +71,9 @@ FlatZinc {
                     ),
                 ),
             ],
+            defines: Some(
+                "c",
+            ),
             ann: [],
         },
     ],

--- a/crates/flatzinc-serde/corpus/set_literals.debug.txt
+++ b/crates/flatzinc-serde/corpus/set_literals.debug.txt
@@ -44,7 +44,7 @@ FlatZinc {
         },
     },
     constraints: [
-        Call {
+        Constraint {
             id: "array_set_element",
             args: [
                 Literal(
@@ -63,9 +63,12 @@ FlatZinc {
                     ),
                 ),
             ],
+            defines: Some(
+                "X_INTRODUCED_0_",
+            ),
             ann: [],
         },
-        Call {
+        Constraint {
             id: "set_in",
             args: [
                 Literal(
@@ -79,6 +82,7 @@ FlatZinc {
                     ),
                 ),
             ],
+            defines: None,
             ann: [],
         },
     ],

--- a/crates/flatzinc-serde/corpus/unit_test_example.debug.txt
+++ b/crates/flatzinc-serde/corpus/unit_test_example.debug.txt
@@ -1,0 +1,282 @@
+FlatZinc {
+    variables: {
+        "X_INTRODUCED_3_": Variable {
+            ty: Bool,
+            domain: None,
+            value: None,
+            ann: [],
+            defined: true,
+            introduced: true,
+        },
+        "b": Variable {
+            ty: Bool,
+            domain: None,
+            value: None,
+            ann: [],
+            defined: true,
+            introduced: false,
+        },
+        "x": Variable {
+            ty: Int,
+            domain: Some(
+                Int(
+                    RangeList::from_iter([1..=3]),
+                ),
+            ),
+            value: None,
+            ann: [],
+            defined: false,
+            introduced: false,
+        },
+        "y": Variable {
+            ty: Int,
+            domain: Some(
+                Int(
+                    RangeList::from_iter([1..=3]),
+                ),
+            ),
+            value: None,
+            ann: [],
+            defined: false,
+            introduced: false,
+        },
+    },
+    arrays: {
+        "X_INTRODUCED_0_": Array {
+            contents: [
+                Int(
+                    1,
+                ),
+                Int(
+                    -1,
+                ),
+            ],
+            ann: [],
+            defined: false,
+            introduced: false,
+        },
+        "X_INTRODUCED_1_": Array {
+            contents: [
+                Int(
+                    1,
+                ),
+                Int(
+                    1,
+                ),
+            ],
+            ann: [],
+            defined: false,
+            introduced: false,
+        },
+        "X_INTRODUCED_4_": Array {
+            contents: [
+                Identifier(
+                    "b",
+                ),
+            ],
+            ann: [],
+            defined: false,
+            introduced: false,
+        },
+        "X_INTRODUCED_5_": Array {
+            contents: [
+                Identifier(
+                    "x",
+                ),
+                Identifier(
+                    "y",
+                ),
+            ],
+            ann: [],
+            defined: false,
+            introduced: false,
+        },
+    },
+    constraints: [
+        Constraint {
+            id: "bool_clause",
+            args: [
+                Array(
+                    [
+                        Identifier(
+                            "X_INTRODUCED_3_",
+                        ),
+                    ],
+                ),
+                Array(
+                    [
+                        Identifier(
+                            "b",
+                        ),
+                    ],
+                ),
+            ],
+            defines: None,
+            ann: [],
+        },
+        Constraint {
+            id: "int_lin_le_reif",
+            args: [
+                Literal(
+                    Identifier(
+                        "X_INTRODUCED_0_",
+                    ),
+                ),
+                Array(
+                    [
+                        Identifier(
+                            "x",
+                        ),
+                        Identifier(
+                            "y",
+                        ),
+                    ],
+                ),
+                Literal(
+                    Int(
+                        -1,
+                    ),
+                ),
+                Literal(
+                    Identifier(
+                        "b",
+                    ),
+                ),
+            ],
+            defines: Some(
+                "b",
+            ),
+            ann: [],
+        },
+        Constraint {
+            id: "int_lin_le_reif",
+            args: [
+                Literal(
+                    Identifier(
+                        "X_INTRODUCED_1_",
+                    ),
+                ),
+                Array(
+                    [
+                        Identifier(
+                            "x",
+                        ),
+                        Identifier(
+                            "y",
+                        ),
+                    ],
+                ),
+                Literal(
+                    Int(
+                        3,
+                    ),
+                ),
+                Literal(
+                    Identifier(
+                        "X_INTRODUCED_3_",
+                    ),
+                ),
+            ],
+            defines: Some(
+                "X_INTRODUCED_3_",
+            ),
+            ann: [],
+        },
+    ],
+    output: [
+        "x",
+        "y",
+    ],
+    solve: SolveObjective {
+        method: Satisfy,
+        objective: None,
+        ann: [
+            Call(
+                AnnotationCall {
+                    id: "seq_search",
+                    args: [
+                        Array(
+                            [
+                                Annotation(
+                                    Call(
+                                        AnnotationCall {
+                                            id: "int_search",
+                                            args: [
+                                                Literal(
+                                                    BaseLiteral(
+                                                        Identifier(
+                                                            "X_INTRODUCED_5_",
+                                                        ),
+                                                    ),
+                                                ),
+                                                Literal(
+                                                    BaseLiteral(
+                                                        Identifier(
+                                                            "input_order",
+                                                        ),
+                                                    ),
+                                                ),
+                                                Literal(
+                                                    BaseLiteral(
+                                                        Identifier(
+                                                            "indomain_min",
+                                                        ),
+                                                    ),
+                                                ),
+                                                Literal(
+                                                    BaseLiteral(
+                                                        Identifier(
+                                                            "complete",
+                                                        ),
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                ),
+                                Annotation(
+                                    Call(
+                                        AnnotationCall {
+                                            id: "bool_search",
+                                            args: [
+                                                Literal(
+                                                    BaseLiteral(
+                                                        Identifier(
+                                                            "X_INTRODUCED_4_",
+                                                        ),
+                                                    ),
+                                                ),
+                                                Literal(
+                                                    BaseLiteral(
+                                                        Identifier(
+                                                            "input_order",
+                                                        ),
+                                                    ),
+                                                ),
+                                                Literal(
+                                                    BaseLiteral(
+                                                        Identifier(
+                                                            "indomain_min",
+                                                        ),
+                                                    ),
+                                                ),
+                                                Literal(
+                                                    BaseLiteral(
+                                                        Identifier(
+                                                            "complete",
+                                                        ),
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                ),
+                            ],
+                        ),
+                    ],
+                },
+            ),
+        ],
+    },
+    version: "1.0",
+}

--- a/crates/flatzinc-serde/corpus/unit_test_example.fzn.json
+++ b/crates/flatzinc-serde/corpus/unit_test_example.fzn.json
@@ -1,0 +1,59 @@
+{
+	"variables": {
+		"x": { "type": "int", "domain": [[1, 3]] },
+		"y": { "type": "int", "domain": [[1, 3]] },
+		"b": { "type": "bool", "defined": true },
+		"X_INTRODUCED_3_": { "type": "bool", "introduced": true, "defined": true }
+	},
+	"arrays": {
+		"X_INTRODUCED_0_": { "a": [1, -1] },
+		"X_INTRODUCED_1_": { "a": [1, 1] },
+		"X_INTRODUCED_4_": { "a": ["b"] },
+		"X_INTRODUCED_5_": { "a": ["x", "y"] }
+	},
+	"constraints": [
+		{ "id": "bool_clause", "args": [["X_INTRODUCED_3_"], ["b"]] },
+		{
+			"id": "int_lin_le_reif",
+			"args": ["X_INTRODUCED_0_", ["x", "y"], -1, "b"],
+			"defines": "b"
+		},
+		{
+			"id": "int_lin_le_reif",
+			"args": ["X_INTRODUCED_1_", ["x", "y"], 3, "X_INTRODUCED_3_"],
+			"defines": "X_INTRODUCED_3_"
+		}
+	],
+	"output": ["x", "y"],
+	"solve": {
+		"method": "satisfy",
+		"ann": [
+			{
+				"id": "seq_search",
+				"args": [
+					[
+						{
+							"id": "int_search",
+							"args": [
+								"X_INTRODUCED_5_",
+								"input_order",
+								"indomain_min",
+								"complete"
+							]
+						},
+						{
+							"id": "bool_search",
+							"args": [
+								"X_INTRODUCED_4_",
+								"input_order",
+								"indomain_min",
+								"complete"
+							]
+						}
+					]
+				]
+			}
+		]
+	},
+	"version": "1.0"
+}

--- a/crates/flatzinc-serde/src/lib.rs
+++ b/crates/flatzinc-serde/src/lib.rs
@@ -186,7 +186,7 @@ impl<Identifier: Display> Display for AnnotationCall<Identifier> {
 #[serde(untagged)]
 pub enum AnnotationLiteral<Identifier = String> {
 	/// Basic FlatZinc literal
-	Literal(Literal<Identifier>),
+	BaseLiteral(Literal<Identifier>),
 	/// An annotation object
 	Annotation(Annotation),
 }
@@ -194,7 +194,7 @@ pub enum AnnotationLiteral<Identifier = String> {
 impl<Idenfier: Display> Display for AnnotationLiteral<Idenfier> {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
-			AnnotationLiteral::Literal(lit) => write!(f, "{lit}"),
+			AnnotationLiteral::BaseLiteral(lit) => write!(f, "{lit}"),
 			AnnotationLiteral::Annotation(ann) => write!(f, "{ann}"),
 		}
 	}
@@ -645,6 +645,7 @@ mod tests {
 	test_file!(encapsulated_string);
 	test_file!(float_sets);
 	test_file!(set_literals);
+	test_file!(unit_test_example);
 
 	fn test_successful_serialization(file: &Path, exp: ExpectFile) {
 		let rdr = BufReader::new(File::open(file).unwrap());
@@ -707,10 +708,10 @@ mod tests {
 		let ann: Annotation<&str> = Annotation::Call(AnnotationCall {
 			id: "bool_search".into(),
 			args: vec![
-				AnnotationArgument::Literal(AnnotationLiteral::Literal(Literal::Identifier(
+				AnnotationArgument::Literal(AnnotationLiteral::BaseLiteral(Literal::Identifier(
 					"input_order".into(),
 				))),
-				AnnotationArgument::Literal(AnnotationLiteral::Literal(Literal::Identifier(
+				AnnotationArgument::Literal(AnnotationLiteral::BaseLiteral(Literal::Identifier(
 					"indomain_min".into(),
 				))),
 			],

--- a/crates/flatzinc-serde/src/range_list.rs
+++ b/crates/flatzinc-serde/src/range_list.rs
@@ -23,6 +23,19 @@ pub struct RangeList<E: PartialOrd> {
 	ranges: Vec<(E, E)>,
 }
 
+impl<E: PartialOrd + Copy> RangeList<E> {
+	/// Returns an Copying iterator for the ranges in the set.
+	#[allow(clippy::type_complexity)]
+	pub fn iter<'a>(
+		&'a self,
+	) -> Map<
+		<&RangeList<E> as IntoIterator>::IntoIter,
+		fn(RangeInclusive<&'a E>) -> RangeInclusive<E>,
+	> {
+		self.into_iter().map(|r| **r.start()..=**r.end())
+	}
+}
+
 impl<E: PartialOrd + Debug> Display for RangeList<E> {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		let mut first = true;


### PR DESCRIPTION
In turn create a split between Annotation type calls and constriants.

TODO:
- [x] Add recursive call annotation test case
- [x] Increase version to `0.3.0`