### PR TITLE
chore: release

### DIFF
--- a/crates/flatzinc-serde/CHANGELOG.md
+++ b/crates/flatzinc-serde/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.0] - 2024-08-12
+
+### Changed
+
+- The `RangeList` type has been moved to a separate crate called `rangelist`. The `RangeList` type is now re-exported from the `flatzinc-serde` crate.
+
+### Fixed
+
+- Add the missing generic type for the `Annotation` variant of `AnnotationLiteral`.
+
+## [0.3.0] - 2024-05-14
+
+### Changed
+
+- The type `Call` has been split into `AnnotationCall` and `Constraint` to allow the more recursive structure of annotation arguments.
+
+### Added
+
+- Add a `RangeList::iter` when its elements implement the `Copy` trait.
+  This method provides an iterator over the intervals of the `RangeList` where the yielded elements are copied.
+
+## [0.2.0] - 2024-04-11
+
+### Changed
+
+- The type for identifiers can now be chosen by the user using a generic type, to allow optimizations like interning.
+  The chosen type must implement the `Serialize` and `Deserialize` traits to recursive keep these traits available.
+  The default type for identifiers is `String`.
+
+### Added
+
+- All structures now implement `Display` and output the structures in the traditional FlatZinc format.
+
+## [0.1.0] - 2024-01-19
+
+### Added
+
+- Add initial defintion of structs to represent FlatZinc JSON format, where `FlatZinc` is the root struct.
+
+[unreleased]: https://github.com/shackle-rs/shackle/releases/compare/flatzinc-serde-v0.3.0......HEAD
+[0.3.0]: https://github.com/shackle-rs/shackle/releases/compare/flatzinc-serde-v0.2.0...flatzinc-serde-v0.3.0
+[0.2.0]: https://github.com/shackle-rs/shackle/releases/compare/flatzinc-serde-v0.1.0...flatzinc-serde-v0.2.0
+[0.1.0]: https://github.com/shackle-rs/shackle/releases/tag/flatzinc-serde-v0.1.0

--- a/crates/flatzinc-serde/Cargo.toml
+++ b/crates/flatzinc-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatzinc-serde"
-version = "0.3.0"
+version = "0.4.0"
 description = "FlatZinc serialization and deserialization"
 authors = [
 	"Jip J. Dekker <jip@dekker.one>",
@@ -17,7 +17,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-rangelist = { path = "../rangelist", version = "0.1" }
+rangelist = { path = "../rangelist", version = "0.2" }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/flatzinc-serde/README.md
+++ b/crates/flatzinc-serde/README.md
@@ -1,0 +1,20 @@
+# FlatZinc Serde
+
+`flatzinc-serde` is a Rust library that provides serialization and deserialization support for the FlatZinc JSON format using the [`serde`](https://serde.rs/) library.
+FlatZinc (JSON) is a representation used to represent decision and optimization problems to solvers of these types of problems.
+This format is used by the [MiniZinc](https://www.minizinc.org/) constraint modelling language.
+
+## Getting Started
+
+Install the library using `cargo`:
+
+```bash
+cargo install flatzinc-serde
+```
+
+Read the [documentation](https://docs.rs/flatzinc-serde) for more information about how to use the library.
+
+## License
+
+This project is licensed under the MPL-2.0 License.
+See the LICENSE file for details.

--- a/crates/rangelist/Cargo.toml
+++ b/crates/rangelist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rangelist"
-version = "0.1.0"
+version = "0.2.0"
 description = "A representation of sets as lists of inclusive ranges"
 authors = ["Jip J. Dekker <jip@dekker.one>"]
 

--- a/crates/xcsp3-serde/CHANGELOG.md
+++ b/crates/xcsp3-serde/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.1] - 2024-08-12
+
+### Changed
+
+- `RangeList` is now provided by a separate crate, `rangelist`.
+  This crate now no longer depends on `flatzinc-serde`.
+
+## [0.1.0] - 2024-06-21
+
+### Added
+
+- Add initial definition of structs to (de)serialize XCSP3-core (XML) format, where `Instance` is the root struct.
+
+[unreleased]: https://github.com/shackle-rs/shackle/releases/compare/xcsp3-serde-v0.1.1......HEAD
+[0.2.0]: https://github.com/shackle-rs/shackle/releases/compare/xcsp3-serde-v0.1.0...xcsp3-serde-v0.1.1
+[0.1.0]: https://github.com/shackle-rs/shackle/releases/tag/xcsp3-serde-v0.1.0

--- a/crates/xcsp3-serde/Cargo.toml
+++ b/crates/xcsp3-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xcsp3-serde"
-version = "0.1.0"
+version = "0.1.1"
 description = "XCSP3 serialization and deserialization"
 authors = ["Jip J. Dekker <jip@dekker.one>"]
 
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-rangelist = { path = "../rangelist", version = "0.1" }
+rangelist = { path = "../rangelist", version = "0.2" }
 nom = "7.1.3"
 
 [dev-dependencies]

--- a/crates/xcsp3-serde/README.md
+++ b/crates/xcsp3-serde/README.md
@@ -1,0 +1,26 @@
+# XCSP3 Serde
+
+`xcsp3-serde` is a Rust library that provides serialization and deserialization support for the XCSP3 (XML) format using the [`serde`](https://serde.rs/) library.
+XCSP3 is a representation used to represent decision and optimization problems.
+This format can be used by some solvers of these types of problems, or used to further process the problem.
+
+## Getting Started
+
+Install the library using `cargo`:
+
+```bash
+cargo install xcsp3-serde
+```
+
+Read the [documentation](https://docs.rs/xcsp3-serde) for more information about how to use the library.
+
+## Limitations
+
+This library currently only supports a subset of the XCSP3 format.
+All features of the XCSP3-core format are supported, but many features outside the core format are not yet supported.
+It is the aim of this library to support the full XCSP3 format in the future.
+
+## License
+
+This project is licensed under the MPL-2.0 License.
+See the LICENSE file for details.


### PR DESCRIPTION
## 🤖 New release
* `flatzinc-serde`: 0.3.0 -> 0.4.0
* `rangelist`: 0.1.0 -> 0.2.0
* `xcsp3-serde`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).