### PR TITLE
chore: release

### DIFF
--- a/crates/flatzinc-serde/CHANGELOG.md
+++ b/crates/flatzinc-serde/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2025-09-25
+
+### Changed
+
+- Update `rangelist` dependency
+
 ## [0.4.2] - 2025-08-13
 
 ### Changed
@@ -56,7 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add initial defintion of structs to represent FlatZinc JSON format, where `FlatZinc` is the root struct.
 
-[unreleased]: https://github.com/shackle-rs/shackle/releases/compare/flatzinc-serde-v0.4.2......HEAD
+[unreleased]: https://github.com/shackle-rs/shackle/releases/compare/flatzinc-serde-v0.4.3......HEAD
+[0.4.3]: https://github.com/shackle-rs/shackle/releases/compare/flatzinc-serde-v0.4.2...flatzinc-serde-v0.4.3
 [0.4.2]: https://github.com/shackle-rs/shackle/releases/compare/flatzinc-serde-v0.4.1...flatzinc-serde-v0.4.2
 [0.4.1]: https://github.com/shackle-rs/shackle/releases/compare/flatzinc-serde-v0.4.0...flatzinc-serde-v0.4.1
 [0.4.0]: https://github.com/shackle-rs/shackle/releases/compare/flatzinc-serde-v0.3.0...flatzinc-serde-v0.4.0

--- a/crates/flatzinc-serde/Cargo.toml
+++ b/crates/flatzinc-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatzinc-serde"
-version = "0.4.2"
+version = "0.4.3"
 description = "FlatZinc serialization and deserialization"
 authors = [
 	"Jip J. Dekker <jip@dekker.one>",
@@ -17,7 +17,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-rangelist = { path = "../rangelist", version = "0.3.1" }
+rangelist = { path = "../rangelist", version = "0.3.2" }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/rangelist/CHANGELOG.md
+++ b/crates/rangelist/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [0.3.2] - 2025-09-25
 
 ### Added
 
@@ -66,7 +66,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add set operations `card`, `disjoint`, `intersect`, `subset`, `superset`,
   `union` for implementers of `IntervalIter`.
 
-[unreleased]: https://github.com/shackle-rs/shackle/releases/compare/rangelist-v0.3.1......HEAD
+[unreleased]: https://github.com/shackle-rs/shackle/releases/compare/rangelist-v0.3.2......HEAD
+[0.3.2]: https://github.com/shackle-rs/shackle/releases/compare/rangelist-v0.3.1...rangelist-v0.3.2
 [0.3.1]: https://github.com/shackle-rs/shackle/releases/compare/rangelist-v0.3.0...rangelist-v0.3.1
 [0.3.0]: https://github.com/shackle-rs/shackle/releases/compare/rangelist-v0.2.0...rangelist-v0.3.0
 [0.2.0]: https://github.com/shackle-rs/shackle/releases/compare/rangelist-v0.1.0...rangelist-v0.2.0

--- a/crates/rangelist/Cargo.toml
+++ b/crates/rangelist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rangelist"
-version = "0.3.1"
+version = "0.3.2"
 description = "A representation of sets as lists of inclusive ranges"
 authors = ["Jip J. Dekker <jip@dekker.one>"]
 

--- a/crates/xcsp3-serde/CHANGELOG.md
+++ b/crates/xcsp3-serde/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2025-09-25
+
+### Changed
+
+- Update `rangelist` dependency
+
 ## [0.1.3] - 2025-08-13
 
 ### Changed
@@ -30,7 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add initial definition of structs to (de)serialize XCSP3-core (XML) format, where `Instance` is the root struct.
 
-[unreleased]: https://github.com/shackle-rs/shackle/releases/compare/xcsp3-serde-v0.1.3......HEAD
+[unreleased]: https://github.com/shackle-rs/shackle/releases/compare/xcsp3-serde-v0.1.4......HEAD
+[0.1.4]: https://github.com/shackle-rs/shackle/releases/compare/xcsp3-serde-v0.1.3...xcsp3-serde-v0.1.4
 [0.1.3]: https://github.com/shackle-rs/shackle/releases/compare/xcsp3-serde-v0.1.2...xcsp3-serde-v0.1.3
 [0.1.2]: https://github.com/shackle-rs/shackle/releases/compare/xcsp3-serde-v0.1.1...xcsp3-serde-v0.1.2
 [0.1.1]: https://github.com/shackle-rs/shackle/releases/compare/xcsp3-serde-v0.1.0...xcsp3-serde-v0.1.1

--- a/crates/xcsp3-serde/Cargo.toml
+++ b/crates/xcsp3-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xcsp3-serde"
-version = "0.1.3"
+version = "0.1.4"
 description = "XCSP3 serialization and deserialization"
 authors = ["Jip J. Dekker <jip@dekker.one>"]
 
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-rangelist = { path = "../rangelist", version = "0.3.1" }
+rangelist = { path = "../rangelist", version = "0.3.2" }
 nom = "8.0.0"
 
 [dev-dependencies]


### PR DESCRIPTION



## 🤖 New release

* `rangelist`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `flatzinc-serde`: 0.4.2 -> 0.4.3
* `xcsp3-serde`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).