### PR TITLE
chore: release

### DIFF
--- a/crates/flatzinc-serde/CHANGELOG.md
+++ b/crates/flatzinc-serde/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2025-11-06
+
+### Changed
+
+- Update `rangelist` dependency
+
 ## [0.4.3] - 2025-09-25
 
 ### Changed

--- a/crates/flatzinc-serde/Cargo.toml
+++ b/crates/flatzinc-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatzinc-serde"
-version = "0.4.3"
+version = "0.4.4"
 description = "FlatZinc serialization and deserialization"
 authors = [
 	"Jip J. Dekker <jip@dekker.one>",
@@ -17,7 +17,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-rangelist = { path = "../rangelist", version = "0.3.2" }
+rangelist = { path = "../rangelist", version = "0.4.0" }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/rangelist/CHANGELOG.md
+++ b/crates/rangelist/CHANGELOG.md
@@ -5,12 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2025-11-06
+
+### Added
+
+- Add `RangeList::from_sorted_ranges` and `RangeList::from_sorted_elements`
+  methods to contruct `RangeList` more efficiently when the input is already
+  sorted.
+
+### Changed
+
+- Replace the ill-defined and implemented `DiscreteElement::elems_between`
+  method with `DiscreteElement::steps_between`, which returns the number of
+  discrete steps between two elements, or `None` if that number overflows
+  `usize`.
+
 ## [0.3.2] - 2025-09-25
 
 ### Added
 
-- Add `Rangelist::set_lower_bound` and `Rangelist::set_upper_bound` methods to
-  tighten the lower and upper bounds of a `Rangelist`.
+- Add `RangeList::set_lower_bound` and `RangeList::set_upper_bound` methods to
+  tighten the lower and upper bounds of a `RangeList`.
 
 ## [0.3.1] - 2025-08-13
 

--- a/crates/rangelist/Cargo.toml
+++ b/crates/rangelist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rangelist"
-version = "0.3.2"
+version = "0.4.0"
 description = "A representation of sets as lists of inclusive ranges"
 authors = ["Jip J. Dekker <jip@dekker.one>"]
 

--- a/crates/xcsp3-serde/CHANGELOG.md
+++ b/crates/xcsp3-serde/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2025-11-06
+
+### Changed
+
+- Update `rangelist` dependency
+
 ## [0.1.4] - 2025-09-25
 
 ### Changed

--- a/crates/xcsp3-serde/Cargo.toml
+++ b/crates/xcsp3-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xcsp3-serde"
-version = "0.1.4"
+version = "0.1.5"
 description = "XCSP3 serialization and deserialization"
 authors = ["Jip J. Dekker <jip@dekker.one>"]
 
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-rangelist = { path = "../rangelist", version = "0.3.2" }
+rangelist = { path = "../rangelist", version = "0.4.0" }
 nom = "8.0.0"
 
 [dev-dependencies]


### PR DESCRIPTION



## 🤖 New release

* `rangelist`: 0.3.2 -> 0.3.3 (✓ API compatible changes)
* `flatzinc-serde`: 0.4.3 -> 0.4.4
* `xcsp3-serde`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).