### PR TITLE
shackle-ty: fix function resolution tie-breaking

### DIFF
--- a/crates/shackle-hir/src/typecheck/tests.rs
+++ b/crates/shackle-hir/src/typecheck/tests.rs
@@ -320,6 +320,38 @@ fn test_function_resolution() {
 		r#"id(x: 1.5)"#,
 		expect!("float"),
 	);
+	tester.check_expression_preamble(
+		r#"
+        function bool: foo(int: x);
+        function int: foo(int: x) = 5;
+		"#,
+		r#"foo(1)"#,
+		expect!("int"),
+	);
+	tester.check_expression_preamble(
+		r#"
+        function int: foo(int: x) = 5;
+        function bool: foo(int: x);
+		"#,
+		r#"foo(1)"#,
+		expect!("int"),
+	);
+	tester.check_expression_preamble(
+		r#"
+        function bool: foo($T: x);
+        function int: foo($T: x) = 5;
+		"#,
+		r#"foo(1)"#,
+		expect!("int"),
+	);
+	tester.check_expression_preamble(
+		r#"
+        function int: foo($T: x) = 5;
+        function bool: foo($T: x);
+		"#,
+		r#"foo(1)"#,
+		expect!("int"),
+	);
 }
 
 #[test]

--- a/crates/shackle-ty/src/functions.rs
+++ b/crates/shackle-ty/src/functions.rs
@@ -411,8 +411,13 @@ pub fn match_fn<'db, T: Overload<'db>>(
 							// They accept our args, but we don't accept theirs, so we're more specific
 							c2.is_candidate = false;
 						} else {
-							// Prefer earlier candidate if both equivalent
-							c2.is_candidate = false;
+							if let Some(prefer_c1) = c1.entry.tie_break(&c2.entry) {
+								if prefer_c1 {
+									c2.is_candidate = false;
+								} else {
+									c1.is_candidate = false;
+								}
+							}
 						}
 					}
 					_ => {

--- a/share/minizinc/std/internal/math.mzn
+++ b/share/minizinc/std/internal/math.mzn
@@ -4,44 +4,44 @@ function int: 'div'(int: x, int: y) =
 	} in shackle_div(x, y);
 function int: shackle_div(int: x, int: y);
 
-function $$E: min(set of $$E: x) =
+function $$E: min(set of $$E: s) =
 	let {
-		constraint mzn_assert_warn(card(x) > 0, "minimum of an empty set is undefined");
-	} in shackle_min(x);
+		constraint mzn_assert_warn(card(s) > 0, "minimum of an empty set is undefined");
+	} in shackle_min(s);
 function $$E: shackle_min(set of $$E: x);
 
-function $$E: max(set of $$E: x) =
+function $$E: max(set of $$E: s) =
 	let {
-		constraint mzn_assert_warn(card(x) > 0, "maximum of an empty set is undefined");
-	} in shackle_max(x);
+		constraint mzn_assert_warn(card(s) > 0, "maximum of an empty set is undefined");
+	} in shackle_max(s);
 function $$E: shackle_max(set of $$E: x);
 
-function $$E: arg_min(array [$$E] of bool: x) =
+function $$E: arg_min(array [$$E] of bool: xs) =
 	let {
-		constraint mzn_assert_warn(length(x) > 0, "arg_min of an empty array is undefined");
-	} in shackle_arg_min(x);
-function $$E: arg_min(array [$$E] of $$T: x) =
+		constraint mzn_assert_warn(length(xs) > 0, "arg_min of an empty array is undefined");
+	} in shackle_arg_min(xs);
+function $$E: arg_min(array [$$E] of $$T: xs) =
 	let {
-		constraint mzn_assert_warn(length(x) > 0, "arg_min of an empty array is undefined");
-	} in shackle_arg_min(x);
-function $$E: arg_min(array [$$E] of float: x) =
+		constraint mzn_assert_warn(length(xs) > 0, "arg_min of an empty array is undefined");
+	} in shackle_arg_min(xs);
+function $$E: arg_min(array [$$E] of float: xs) =
 	let {
-		constraint mzn_assert_warn(length(x) > 0, "arg_min of an empty array is undefined");
-	} in shackle_arg_min(x);
+		constraint mzn_assert_warn(length(xs) > 0, "arg_min of an empty array is undefined");
+	} in shackle_arg_min(xs);
 function $$E: shackle_arg_min(array [$$E] of $T: x);
 
-function $$E: arg_max(array [$$E] of bool: x) =
+function $$E: arg_max(array [$$E] of bool: xs) =
 	let {
-		constraint mzn_assert_warn(length(x) > 0, "arg_max of an empty array is undefined");
-	} in shackle_arg_max(x);
-function $$E: arg_max(array [$$E] of $$T: x) =
+		constraint mzn_assert_warn(length(xs) > 0, "arg_max of an empty array is undefined");
+	} in shackle_arg_max(xs);
+function $$E: arg_max(array [$$E] of $$T: xs) =
 	let {
-		constraint mzn_assert_warn(length(x) > 0, "arg_max of an empty array is undefined");
-	} in shackle_arg_max(x);
-function $$E: arg_max(array [$$E] of float: x) =
+		constraint mzn_assert_warn(length(xs) > 0, "arg_max of an empty array is undefined");
+	} in shackle_arg_max(xs);
+function $$E: arg_max(array [$$E] of float: xs) =
 	let {
-		constraint mzn_assert_warn(length(x) > 0, "arg_max of an empty array is undefined");
-	} in shackle_arg_max(x);
+		constraint mzn_assert_warn(length(xs) > 0, "arg_max of an empty array is undefined");
+	} in shackle_arg_max(xs);
 function $$E: shackle_arg_max(array [$$E] of $T: x);
 
 function int: pow(int: x, int: y) =


### PR DESCRIPTION
Tie-breaking was only invoked in the non-polymorphic case, meaning we could select wrong versions of them.